### PR TITLE
chore(CI): temporarily enable `make` for servicebot to integrate cc-mk-include

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -11,3 +11,5 @@ renovatebot:
     enable: true
 semaphore:
   enable: true
+make:
+  enable: true


### PR DESCRIPTION
Unsure if maintainers will want to keep `make` [enabled](https://confluentinc.atlassian.net/wiki/spaces/ADP/pages/2871296194/Add+SemaphoreCI#pipeline_type%3A-cc_mk_include) by default, but at the very least this will include the basic Makefile in the servicebot PR, similar to https://github.com/confluentinc/intellij/pull/5/changes

Needed to unblock https://github.com/confluentinc/confluent-sql/pull/17