### PR TITLE
Fix streaming mode CREATE TABLE and friends from returning prematurely

### DIFF
--- a/src/confluent_sql/cursor.py
+++ b/src/confluent_sql/cursor.py
@@ -30,7 +30,7 @@ from .exceptions import (
     ProgrammingError,
 )
 from .execution_mode import ExecutionMode
-from .statement import Phase, Statement
+from .statement import Statement
 from .types import convert_statement_parameters
 
 if TYPE_CHECKING:
@@ -668,16 +668,14 @@ class Cursor:
 
             # Determine if the statement is ready based on execution mode and statement type
             if self._execution_mode.is_streaming:
-                # In streaming mode, statements are ready when RUNNING (or terminal states)
-                # This handles:
-                # - Regular streaming queries
-                # - Streaming DDL (CTAS in streaming mode)
-                # Note: CTAS is currently misreported as bounded due to a server bug
-                statement_ready = statement.is_running or statement.phase in [
-                    Phase.COMPLETED,
-                    Phase.STOPPED,
-                    Phase.FAILED,
-                ]
+                # In streaming mode, readiness depends on statement type:
+                if statement.is_pure_ddl:
+                    # Pure DDL (CREATE TABLE, CREATE VIEW, etc.) must complete fully
+                    # before the created/modified objects are ready for use
+                    statement_ready = statement.phase.is_terminal
+                else:
+                    # Streaming queries and CTAS are ready when RUNNING or in terminal state
+                    statement_ready = statement.is_running or statement.phase.is_terminal
             else:
                 # In snapshot mode, use the statement's is_ready property
                 # which waits for completion for bounded statements

--- a/src/confluent_sql/statement.py
+++ b/src/confluent_sql/statement.py
@@ -96,6 +96,8 @@ class ChangelogRow:
 
 
 class Phase(Enum):
+    """Statement execution phases with terminal state detection."""
+
     PENDING = "PENDING"
     RUNNING = "RUNNING"
     COMPLETED = "COMPLETED"
@@ -111,11 +113,37 @@ class Phase(Enum):
     # never returned by the api.
     DELETED = "DELETED"
 
+    def __init__(self, value: str) -> None:
+        """Initialize Phase enum member."""
+        self._value_ = value
+
+    @property
+    def is_terminal(self) -> bool:
+        """Check if this phase is a terminal state (statement execution has ended).
+
+        Terminal states are those where the statement is no longer executing and will
+        not transition to any other state.
+
+        Returns:
+            True if the phase is COMPLETED, STOPPED, FAILED, or DELETED. False otherwise.
+        """
+        # Terminal phase values defined at class level
+        return self.value in Phase._TERMINAL_PHASES  # type: ignore[attr-defined]
+
+
+# Class-level constant defining terminal phases
+Phase._TERMINAL_PHASES = frozenset({"COMPLETED", "STOPPED", "FAILED", "DELETED"})  # type: ignore[attr-defined]
+
 
 @dataclass
 class Statement:
     """Represents a Confluent SQL statement, including its metadata, spec, status,
     and parsed traits such as schema, sql kind, etc."""
+
+    # SQL kinds that represent pure DDL statements (create/modify schema objects)
+    _PURE_DDL_KINDS = frozenset(
+        {"CREATE_TABLE", "DROP_TABLE", "CREATE_VIEW", "DROP_VIEW", "ALTER_TABLE"}
+    )
 
     # From the cursor that created this statement ...
     connection: Connection
@@ -220,6 +248,19 @@ class Statement:
     @property
     def sql_kind(self) -> str:
         return self._possible_traits().sql_kind
+
+    @property
+    def is_pure_ddl(self) -> bool:
+        """Check if this statement is a pure DDL statement that creates or modifies schema objects.
+
+        Pure DDL statements need to complete fully before the created/modified objects
+        are ready for use, unlike streaming queries or CTAS which are ready when RUNNING.
+
+        Returns:
+            True if the statement is one of: CREATE_TABLE, DROP_TABLE, CREATE_VIEW,
+            DROP_VIEW, ALTER_TABLE. False otherwise.
+        """
+        return self.sql_kind in self._PURE_DDL_KINDS
 
     @property
     def is_append_only(self) -> bool:

--- a/tests/integration/test_cursor.py
+++ b/tests/integration/test_cursor.py
@@ -276,6 +276,47 @@ class TestCursor:
         cursor.delete_statement()
         assert cursor._statement.is_deleted
 
+    @pytest.mark.slow
+    def test_streaming_ddl_create_table_completes(self, connection: Connection):
+        """Test that executing CREATE TABLE in streaming mode waits for completion.
+
+        This validates the fix for streaming DDL statements: pure DDL statements
+        (like CREATE TABLE) in streaming mode should wait for the statement to
+        reach a terminal phase (COMPLETED) before returning to the caller, not
+        just return when RUNNING.
+
+        After the CREATE TABLE completes, the table should be immediately usable.
+        """
+        # Create a unique table name for this test (use underscores instead of hyphens)
+        table_name = f"test_streaming_ddl_{uuid4().hex[:8]}"
+
+        # Create the table using streaming cursor mode
+        # This should wait for the statement to reach COMPLETED phase
+        cursor = connection.streaming_cursor()
+        cursor.execute(f"CREATE TABLE {table_name} (id INT, name STRING)")
+        statement = cursor.statement
+        assert statement is not None
+
+        # Verify the statement has completed (not just RUNNING)
+        assert statement.phase == Phase.COMPLETED
+        assert statement.is_pure_ddl is True
+
+        # Verify the table exists and is usable by querying it
+        verify_cursor = connection.cursor()
+        verify_cursor.execute(f"SELECT COUNT(*) as row_count FROM {table_name}")
+        results = verify_cursor.fetchall()
+        assert len(results) == 1  # Should have one row with count
+        verify_cursor.close()
+        cursor.close()
+
+        # Cleanup: Drop the created table
+        cleanup_cursor = connection.cursor()
+        cleanup_cursor.execute(f"DROP TABLE IF EXISTS {table_name}")
+        cleanup_cursor.close()
+
+        # Delete the statement
+        connection.delete_statement(statement)
+
 
 @pytest.mark.integration
 class TestCursorParameterInterpolation:

--- a/tests/unit/test_cursor_unit.py
+++ b/tests/unit/test_cursor_unit.py
@@ -333,6 +333,193 @@ class TestExecute:
         ):
             mock_connection_cursor.execute("SELECT * FROM table", timeout=5)
 
+    def test_streaming_pure_ddl_waits_for_terminal_through_running(
+        self,
+        mock_connection_cursor: Cursor,
+        statement_response_factory: StatementResponseFactory,
+        mocker,
+    ):
+        """Test that streaming mode CREATE TABLE waits for terminal phase, not just RUNNING.
+
+        This tests the core behavior fix: pure DDL statements in streaming mode should
+        not return when RUNNING, but should wait until the statement reaches a terminal
+        phase (COMPLETED, STOPPED, FAILED, or DELETED).
+        """
+        # Set execution mode to STREAMING_DDL
+        mock_connection_cursor._execution_mode = ExecutionMode.STREAMING_DDL
+
+        # Simulate statement progressing: RUNNING -> RUNNING -> COMPLETED
+        call_count = [0]
+
+        def get_statement_side_effect(statement_name):  # noqa: ARG001
+            call_count[0] += 1
+            if call_count[0] <= 2:
+                # First two calls: return RUNNING phase
+                return statement_response_factory(
+                    sql_statement="CREATE TABLE new_table (id INT)",
+                    sql_kind="CREATE_TABLE",
+                    phase="RUNNING",
+                    is_append_only=True,
+                )
+            else:
+                # Third call and beyond: return COMPLETED phase
+                return statement_response_factory(
+                    sql_statement="CREATE TABLE new_table (id INT)",
+                    sql_kind="CREATE_TABLE",
+                    phase="COMPLETED",
+                    is_append_only=True,
+                )
+
+        mock_connection_cursor._connection._get_statement.side_effect = (  # type: ignore
+            get_statement_side_effect
+        )
+
+        # Mock time functions to avoid actual waiting
+        mocker.patch("time.sleep", return_value=None)
+        mocker.patch("time.monotonic", return_value=1000000.0)
+
+        # Execute should succeed, waiting through RUNNING until COMPLETED
+        mock_connection_cursor.execute("CREATE TABLE new_table (id INT)")
+
+        # Verify the statement is now in COMPLETED phase
+        assert mock_connection_cursor._statement is not None
+        assert mock_connection_cursor._statement.phase.name == "COMPLETED"
+
+        # Verify we polled the statement at least 3 times (2 RUNNING + 1 COMPLETED)
+        assert call_count[0] >= 3
+
+    def test_streaming_query_does_not_wait_for_terminal(
+        self,
+        mock_connection_cursor: Cursor,
+        statement_response_factory: StatementResponseFactory,
+        mocker,
+    ):
+        """Test that streaming queries return immediately when RUNNING, not waiting for terminal.
+
+        This contrasts with streaming DDL: a SELECT statement should return when RUNNING,
+        while a CREATE TABLE should wait for terminal phase.
+        """
+        # Set execution mode to STREAMING_QUERY
+        mock_connection_cursor._execution_mode = ExecutionMode.STREAMING_QUERY
+
+        call_count = [0]
+
+        def get_statement_side_effect(statement_name):  # noqa: ARG001
+            call_count[0] += 1
+            # Always return RUNNING - should return on first call for non-DDL statements
+            return statement_response_factory(
+                sql_statement="SELECT * FROM table",
+                sql_kind="SELECT",
+                phase="RUNNING",
+                is_append_only=True,
+                is_bounded=False,
+            )
+
+        mock_connection_cursor._connection._get_statement.side_effect = (  # type: ignore
+            get_statement_side_effect
+        )
+
+        # Mock time functions
+        mocker.patch("time.sleep", return_value=None)
+        mocker.patch("time.monotonic", return_value=1000000.0)
+
+        # Execute should succeed immediately (returns on RUNNING for non-DDL)
+        mock_connection_cursor.execute("SELECT * FROM table")
+
+        # Verify the statement is in RUNNING phase
+        assert mock_connection_cursor._statement is not None
+        assert mock_connection_cursor._statement.phase.name == "RUNNING"
+
+        # Verify we only polled once (should not keep waiting once RUNNING)
+        assert call_count[0] == 1
+
+    def test_streaming_pure_ddl_returns_on_failed_terminal(
+        self,
+        mock_connection_cursor: Cursor,
+        statement_response_factory: StatementResponseFactory,
+        mocker,
+    ):
+        """Test that streaming DDL returns immediately on FAILED (terminal) phase.
+
+        Pure DDL statements should return as soon as they reach any terminal phase,
+        including FAILED.
+        """
+        # Set execution mode to STREAMING_DDL
+        mock_connection_cursor._execution_mode = ExecutionMode.STREAMING_DDL
+
+        call_count = [0]
+
+        def get_statement_side_effect(statement_name):  # noqa: ARG001
+            call_count[0] += 1
+            # Always return FAILED
+            return statement_response_factory(
+                sql_statement="CREATE TABLE new_table (id INT)",
+                sql_kind="CREATE_TABLE",
+                phase="FAILED",
+                status_detail="Table already exists",
+            )
+
+        mock_connection_cursor._connection._get_statement.side_effect = (  # type: ignore
+            get_statement_side_effect
+        )
+
+        # Mock time functions
+        mocker.patch("time.sleep", return_value=None)
+        mocker.patch("time.monotonic", return_value=1000000.0)
+
+        # Execute should call _raise_if_statement_is_broken due to FAILED phase
+        with pytest.raises(OperationalError, match="Statement .* failed"):
+            mock_connection_cursor.execute("CREATE TABLE new_table (id INT)")
+
+        # Verify we only polled once (should return on first FAILED check)
+        assert call_count[0] == 1
+
+    def test_streaming_non_ddl_normal_bounded_returns_on_running(
+        self,
+        mock_connection_cursor: Cursor,
+        statement_response_factory: StatementResponseFactory,
+        mocker,
+    ):
+        """Test that streaming queries return on RUNNING regardless of boundedness.
+
+        This validates the normal (non-workaround) case where a streaming SELECT
+        statement with normal is_bounded=False returns immediately when RUNNING.
+        """
+        # Set execution mode to STREAMING_QUERY
+        mock_connection_cursor._execution_mode = ExecutionMode.STREAMING_QUERY
+
+        call_count = [0]
+
+        def get_statement_side_effect(statement_name):  # noqa: ARG001
+            call_count[0] += 1
+            # Always return RUNNING with is_bounded=False (normal case)
+            return statement_response_factory(
+                sql_statement="SELECT COUNT(*) FROM users",
+                sql_kind="SELECT",
+                phase="RUNNING",
+                is_append_only=False,  # Non-append-only aggregation query
+                is_bounded=False,  # Normal: streaming query is not bounded
+            )
+
+        mock_connection_cursor._connection._get_statement.side_effect = (  # type: ignore
+            get_statement_side_effect
+        )
+
+        # Mock time functions
+        mocker.patch("time.sleep", return_value=None)
+        mocker.patch("time.monotonic", return_value=1000000.0)
+
+        # Execute should succeed and return immediately
+        mock_connection_cursor.execute("SELECT COUNT(*) FROM users")
+
+        # Verify the statement is in RUNNING phase
+        assert mock_connection_cursor._statement is not None
+        assert mock_connection_cursor._statement.phase.name == "RUNNING"
+        assert mock_connection_cursor._statement.is_bounded is False
+
+        # Verify we only polled once (should return immediately on RUNNING)
+        assert call_count[0] == 1
+
 
 @pytest.mark.unit
 class TestCursorInterpolatingParameters:

--- a/tests/unit/test_statement_unit.py
+++ b/tests/unit/test_statement_unit.py
@@ -24,6 +24,28 @@ class TestOp:
 
 
 @pytest.mark.unit
+class TestPhaseIsTerminal:
+    """Tests for Phase.is_terminal property."""
+
+    @pytest.mark.parametrize(
+        "phase,expected",
+        [
+            (Phase.COMPLETED, True),
+            (Phase.STOPPED, True),
+            (Phase.FAILED, True),
+            (Phase.DELETED, True),
+            (Phase.RUNNING, False),
+            (Phase.PENDING, False),
+            (Phase.DEGRADED, False),
+            (Phase.STOPPING, False),
+        ],
+    )
+    def test_is_terminal(self, phase: Phase, expected: bool):
+        """Test that is_terminal property returns correct boolean for each phase."""
+        assert phase.is_terminal == expected
+
+
+@pytest.mark.unit
 class TestStatementIsReady:
     """Tests for Statement.is_ready property."""
 
@@ -351,6 +373,49 @@ class TestStatementProperties:
             match="Statement traits are not available.",
         ):
             _ = statement.sql_kind
+
+    @pytest.mark.parametrize(
+        "sql_kind,expected",
+        [
+            ("CREATE_TABLE", True),
+            ("DROP_TABLE", True),
+            ("CREATE_VIEW", True),
+            ("DROP_VIEW", True),
+            ("ALTER_TABLE", True),
+            ("SELECT", False),
+            ("INSERT", False),
+            ("UPDATE", False),
+            ("DELETE", False),
+        ],
+    )
+    def test_is_pure_ddl(
+        self,
+        sql_kind: str,
+        expected: bool,
+        mock_connection: Connection,
+        statement_response_factory: StatementResponseFactory,
+    ):
+        """Test that is_pure_ddl property correctly identifies pure DDL statements."""
+        statement_json = statement_response_factory(sql_kind=sql_kind)
+        statement = Statement.from_response(mock_connection, statement_json)
+        assert statement.is_pure_ddl == expected
+
+    def test_is_pure_ddl_raises_when_no_traits(
+        self,
+        mock_connection: Connection,
+        statement_response_factory: StatementResponseFactory,
+    ):
+        """Test that is_pure_ddl property raises InterfaceError when
+        failed statement traits are missing."""
+
+        statement_json = statement_response_factory(phase="FAILED")
+        statement = Statement.from_response(mock_connection, statement_json)
+
+        with pytest.raises(
+            InterfaceError,
+            match="Statement traits are not available.",
+        ):
+            _ = statement.is_pure_ddl
 
     def test_scaling_status_present(
         self,


### PR DESCRIPTION
# Summary
This PR fixes a critical issue where streaming mode DDL statements (CREATE TABLE, CREATE VIEW, DROP TABLE, DROP VIEW, ALTER TABLE) return control to the caller when entering RUNNING state, before the created/modified schema objects are actually ready to use. The solution automatically detects pure DDL statements and ensures they wait for terminal completion before returning, while non-DDL streaming statements continue to return immediately on RUNNING. This enables seamless table creation and immediate usage in streaming mode without requiring manual completion polling.

## Changes
Core Implementation (src/confluent_sql/statement.py):

  * Added `Phase._TERMINAL_PHASES` class constant to centralize terminal phase definitions
  * Added `Phase.is_terminal` property to cleanly identify terminal execution states
  * Added `Statement._PURE_DDL_KINDS `class constant defining pure DDL statement types
  * Added `Statement.is_pure_ddl` property to identify schema-modifying statements
  * Cursor Execution Logic (src/confluent_sql/cursor.py): adjusted `_wait_for_statement_ready()` exit logic.

Updated Cursor._wait_for_statement_ready() to differentiate wait behavior by statement type:
  * Pure DDL: waits for terminal phase (`COMPLETED`, `STOPPED`, `FAILED`, `DELETED`)
  * Other streaming statements: returns on `RUNNING` or any terminal phase
  * Snapshot mode: unchanged behavior
  
## Test Coverage (tests/unit/ and tests/integration/):

  * Added 8 parameterized unit tests for `Phase.is_terminal` covering all phase values
  * Added 10 parameterized unit tests for Statement.is_pure_ddl covering DDL and non-DDL kinds
  * Added 4 cursor unit tests validating streaming DDL wait behavior in various scenarios
  * Added integration test `test_streaming_ddl_create_table_completes` that verifies table creation completes and is immediately usable


This is a PR to merge into the existing branch implementing the streaming changelog compressor.