### PR TITLE
Rename changelog.py and its contents to be readers, not changelog.

### DIFF
--- a/src/confluent_sql/__init__.py
+++ b/src/confluent_sql/__init__.py
@@ -5,7 +5,6 @@ This module provides a DB-API v2 compliant interface for connecting to and
 executing SQL queries against Confluent SQL services.
 """
 
-from .changelog import ChangeloggedRow
 from .changelog_compressor import ChangelogCompressor
 from .connection import Connection, connect
 from .cursor import Cursor
@@ -25,6 +24,7 @@ from .exceptions import (
     TypeMismatchError,
     Warning,
 )
+from .result_readers import ChangeloggedRow
 from .statement import Op
 from .types import SqlNone, YearMonthInterval
 

--- a/src/confluent_sql/changelog_compressor.py
+++ b/src/confluent_sql/changelog_compressor.py
@@ -19,12 +19,12 @@ Usage:
 
     # Generator exits when query is externally stopped/deleted or fails
 
-Compressors consume raw changelog events from RawChangelogProcessor (via the cursor)
+Compressors consume raw changelog events from ChangelogEventReader (via the cursor)
 and apply operations to maintain the compressed result set. Storage strategies are
 automatically selected based on whether the statement has upsert columns (dict-based
 keyed lookup vs list-based scanning) and whether results are tuples or dicts.
 
-For low-level changelog fetching without state management, see the `changelog` module.
+For low-level changelog fetching without state management, see the `result_readers` module.
 """
 
 from __future__ import annotations
@@ -35,8 +35,8 @@ import logging
 from collections.abc import Generator
 from typing import TYPE_CHECKING, Generic, TypeVar, cast
 
-from .changelog import ChangeloggedRow, ResultTupleOrDict, StatementResultTuple
 from .exceptions import InterfaceError, StatementStoppedError
+from .result_readers import ChangeloggedRow, ResultTupleOrDict, StatementResultTuple
 from .statement import Op, Schema, Statement
 from .types import StrAnyDict
 

--- a/src/confluent_sql/connection.py
+++ b/src/confluent_sql/connection.py
@@ -130,7 +130,7 @@ class Connection:
         If it has already been at least this long since the most recent fetch of results for the
         statement, then no delay will happen.
 
-        Referenced by the changelog processor when fetching pages of results for individual
+        Referenced by the result reader when fetching pages of results for individual
         statements.
     """
 
@@ -186,7 +186,7 @@ class Connection:
         if statement_results_page_fetch_pause_millis < 0:
             raise InterfaceError("result_page_fetch_pause_millis must be non-negative")
 
-        # Will be referenced by cursor / changelog processor when
+        # Will be referenced by cursor / result reader when
         # fetching pages of results for individual statements.
         self.statement_results_page_fetch_pause_secs = (
             statement_results_page_fetch_pause_millis / 1000.0

--- a/src/confluent_sql/cursor.py
+++ b/src/confluent_sql/cursor.py
@@ -14,14 +14,6 @@ import warnings
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, TypeAlias
 
-from .changelog import (
-    AppendOnlyChangelogProcessor,
-    ChangeloggedRow,
-    ChangelogProcessor,
-    FetchMetrics,
-    RawChangelogProcessor,
-    ResultTupleOrDict,
-)
 from .changelog_compressor import ChangelogCompressor, create_changelog_compressor
 from .exceptions import (
     ComputePoolExhaustedError,
@@ -30,6 +22,14 @@ from .exceptions import (
     ProgrammingError,
 )
 from .execution_mode import ExecutionMode
+from .result_readers import (
+    AppendOnlyResultReader,
+    ChangelogEventReader,
+    ChangeloggedRow,
+    FetchMetrics,
+    ResultReader,
+    ResultTupleOrDict,
+)
 from .statement import Statement
 from .types import convert_statement_parameters
 
@@ -118,7 +118,7 @@ class Cursor:
 
         # Statement execution state
         self._statement: Statement | None = None
-        self._changelog_processor: AppendOnlyChangelogProcessor | RawChangelogProcessor | None = (
+        self._result_reader: AppendOnlyResultReader | ChangelogEventReader | None = (
             None
         )
 
@@ -198,7 +198,7 @@ class Cursor:
         # Reset internal state
         self._statement = None
         self._statement_handle = None
-        self._changelog_processor = None
+        self._result_reader = None
         self.rowcount = -1
         self._next_page = None
 
@@ -230,17 +230,17 @@ class Cursor:
                 "DDL statements do not produce result sets."
             )
 
-    def _get_changelog_processor(self) -> ChangelogProcessor[Any]:
-        """Raise if changelog processor is not initialized, which should be the case if the
+    def _get_result_reader(self) -> ResultReader[Any]:
+        """Raise if result reader is not initialized, which should be the case if the
         statement is not append-only or if we haven't successfully waited for the statement to
         be ready."""
-        if self._changelog_processor is None:
+        if self._result_reader is None:
             raise InterfaceError(
-                "Changelog processor not initialized. This likely means the statement"
+                "Result reader not initialized. This likely means the statement"
                 " is not ready for fetching results yet."
             )  # pragma: no cover
 
-        return self._changelog_processor
+        return self._result_reader
 
     def fetchone(self) -> ResultRow | None:
         """
@@ -279,7 +279,7 @@ class Cursor:
         self._raise_if_closed()
         self._raise_if_ddl_mode()
 
-        return self._get_changelog_processor().fetchone()
+        return self._get_result_reader().fetchone()
 
     def fetchmany(self, size: int | None = None) -> list[ResultRow]:
         """
@@ -323,7 +323,7 @@ class Cursor:
         self._raise_if_closed()
         self._raise_if_ddl_mode()
 
-        return self._get_changelog_processor().fetchmany(
+        return self._get_result_reader().fetchmany(
             size if size is not None else self.arraysize
         )
 
@@ -352,7 +352,7 @@ class Cursor:
         self._raise_if_closed()
         self._raise_if_ddl_mode()
 
-        return self._get_changelog_processor().fetchall()
+        return self._get_result_reader().fetchall()
 
     def __iter__(self) -> Iterator[ResultRow]:
         """Return the cursor as an iterator, so that our __next__ can ensure .close() checks."""
@@ -361,10 +361,10 @@ class Cursor:
         return self
 
     def __next__(self) -> ResultRow:
-        """Defer to the changelog processor's iterator after proving
+        """Defer to the result reader's iterator after proving
         the cursor is not yet closed."""
         self._raise_if_closed()
-        return self._get_changelog_processor().__next__()
+        return self._get_result_reader().__next__()
 
     def close(self) -> None:
         """
@@ -391,7 +391,7 @@ class Cursor:
 
             self.rowcount = -1
             self._closed = True
-            self._changelog_processor = None
+            self._result_reader = None
 
     def setinputsizes(self, sizes) -> None:
         """
@@ -461,17 +461,17 @@ class Cursor:
         return (
             self._statement is not None
             and self._statement.schema is not None
-            and self._get_changelog_processor().may_have_results
+            and self._get_result_reader().may_have_results
         )
 
     @property
     def metrics(self) -> FetchMetrics:
-        """Return the current fetch metrics from the changelog processor, if available."""
-        if self._changelog_processor is None:
+        """Return the current fetch metrics from the result reader, if available."""
+        if self._result_reader is None:
             raise InterfaceError(
-                "No changelog processor initialized, cannot get metrics."
+                "No result reader initialized, cannot get metrics."
             )  # pragma: no cover
-        return self._changelog_processor.metrics
+        return self._result_reader.metrics
 
     @property
     def as_dict(self) -> bool:
@@ -627,22 +627,22 @@ class Cursor:
             self._raise_if_statement_is_broken(statement)
 
             # If we can fetch results based on execution mode and statement state,
-            # create the changelog processor and exit the polling loop.
+            # create the result reader and exit the polling loop.
             if statement.can_fetch_results(self._execution_mode):
                 if statement.is_append_only:
-                    # Create changelog processor for append-only statements, will
+                    # Create result reader for append-only statements, will
                     # return row tuples or dicts depending on self._results_as_dicts.
-                    self._changelog_processor = AppendOnlyChangelogProcessor(
+                    self._result_reader = AppendOnlyResultReader(
                         self._connection,
                         self._statement,
                         self._execution_mode,
                         as_dict=self._results_as_dicts,
                     )
                 else:
-                    # Use a RawChangelogProcessor that will return pairs of the changelog
+                    # Use a ChangelogEventReader that will return pairs of the changelog
                     # operation and the type-promoted row data as a dict or tuple depending
                     # on self._results_as_dicts.
-                    self._changelog_processor = RawChangelogProcessor(
+                    self._result_reader = ChangelogEventReader(
                         self._connection,
                         self._statement,
                         self._execution_mode,

--- a/src/confluent_sql/result_readers.py
+++ b/src/confluent_sql/result_readers.py
@@ -1,21 +1,21 @@
 """
-Changelog fetching and conversion for Confluent SQL DB-API driver.
+Result reading and buffering for Confluent SQL DB-API driver.
 
-This module provides low-level changelog processors that fetch statement results
+This module provides low-level result readers that fetch statement results
 from the server, handle paging, and convert row data from JSON to Python types.
 
-- AppendOnlyChangelogProcessor: For append-only streaming (or all snapshot mode)
+- AppendOnlyResultReader: For append-only streaming (or all snapshot mode)
   queries (returns row data only).
-- RawChangelogProcessor: For non-append-only queries -- a subset of streaming queries
+- ChangelogEventReader: For non-append-only queries -- a subset of streaming queries
   (returns ChangeloggedRow with operation + row).
 
-These processors fetch and expose either result rows or changelog events including
+These readers fetch and expose either result rows or changelog events including
 result rows but do NOT apply or interpret them. These implementations back
 the iteration, fetchone/fetchmany/fetchall methods of our Cursor class.
 
 For stateful compression of changelog events into a logical result set, see
 the `changelog_compressor` module, which makes use of the sequence of ChangeloggedRow
-returned by RawChangelogProcessor to produce a compressed result set ("interpreted changelog")
+returned by ChangelogEventReader to produce a compressed result set ("interpreted changelog")
 that applies the changelog operations to maintain the current state of each row in the result
 and the logical result set at large over time. That functionality is exposed from the Cursor
 class's `changelog_compressor()` method (only callable for non-append-only streaming statements).
@@ -41,8 +41,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-ProcessorOutput = TypeVar("ProcessorOutput")
-"""Type that a changelog processor produces as output from its __iter__ method."""
+ReaderOutput = TypeVar("ReaderOutput")
+"""Type that a result reader produces as output from its __iter__ method."""
 
 
 StatementResultTuple: TypeAlias = tuple[SupportedPythonTypes, ...]
@@ -51,30 +51,30 @@ StatementResultTuple: TypeAlias = tuple[SupportedPythonTypes, ...]
 
 
 ResultTupleOrDict: TypeAlias = StatementResultTuple | StrAnyDict
-"""Output type for AppendOnlyChangelogProcessor fetch methods and iteration."""
+"""Output type for AppendOnlyResultReader fetch methods and iteration."""
 
 
 @dataclass()
 class FetchMetrics:
-    """Holds metrics related to fetch results route operations in ChangelogProcessor."""
+    """Holds metrics related to fetch results route operations in ResultReader."""
 
     total_page_fetches: int = 0
-    """Total number of times the processor fetched a page of results from the server."""
+    """Total number of times the reader fetched a page of results from the server."""
 
     total_changelog_rows_fetched: int = 0
     """Total number of changelog rows fetched from the server across all pages."""
 
     empty_page_fetches: int = 0
-    """Number of times the processor fetched a page of results that contained no rows."""
+    """Number of times the reader fetched a page of results that contained no rows."""
 
     fetch_request_secs: float = 0.0
     """Total elapsed seconds spent on results fetch operations (excluding any pauses)."""
 
     paused_times: int = 0
-    """Number of times the processor paused before fetching the next page of results."""
+    """Number of times the reader paused before fetching the next page of results."""
 
     paused_secs: float = 0.0
-    """Total number of seconds the processor spent paused before fetching pages."""
+    """Total number of seconds the reader spent paused before fetching pages."""
 
     _before_fetch_timestamp: float | None = None
     """Internal timestamp to track when a fetch operation started, used for metrics calculation."""
@@ -87,7 +87,7 @@ class FetchMetrics:
         return self.total_changelog_rows_fetched / self.total_page_fetches
 
     def paused_before_fetch(self, pause_secs: float) -> None:
-        """Record that the processor paused for a some time before fetching results."""
+        """Record that the reader paused for some time before fetching results."""
         self.paused_times += 1
         self.paused_secs += pause_secs
 
@@ -114,15 +114,15 @@ class FetchMetrics:
         self._before_fetch_timestamp = None
 
 
-class ChangelogProcessor(Generic[ProcessorOutput], abc.ABC):
-    """Abstract base class for changelog processors.
+class ResultReader(Generic[ReaderOutput], abc.ABC):
+    """Abstract base class for result readers.
 
     Important: Iteration vs Fetch Methods Behavior
     ------------------------------------------------
-    This processor provides two ways to consume results, with different
+    This reader provides two ways to consume results, with different
     blocking behaviors in streaming mode:
 
-    1. **Iteration (for row in processor):**
+    1. **Iteration (for row in reader):**
        - Always blocking in both snapshot and streaming modes
        - Waits for data to become available or until definitively complete
        - Suitable for consuming complete result sets
@@ -140,10 +140,10 @@ class ChangelogProcessor(Generic[ProcessorOutput], abc.ABC):
     """
 
     _connection: Connection
-    """The connection associated with this changelog processor."""
+    """The connection associated with this result reader."""
 
     _statement: Statement
-    """The statement associated with this changelog processor."""
+    """The statement associated with this result reader."""
 
     _as_dict: bool
     """Whether to return the row portion of results as dicts or tuples."""
@@ -160,7 +160,7 @@ class ChangelogProcessor(Generic[ProcessorOutput], abc.ABC):
        no more pages to fetch (distinguished from the initial state by
        `_fetch_next_page_called` being set to `True`)."""
 
-    _results: deque[ProcessorOutput]
+    _results: deque[ReaderOutput]
     """Deque of unconsumed results. Rows are removed via popleft() as they
     are consumed, freeing memory incrementally."""
 
@@ -172,7 +172,7 @@ class ChangelogProcessor(Generic[ProcessorOutput], abc.ABC):
     """Metrics related to results fetching operations"""
 
     _execution_mode: ExecutionMode
-    """The execution mode for this processor (snapshot vs streaming)."""
+    """The execution mode for this reader (snapshot vs streaming)."""
 
     def __init__(
         self,
@@ -190,15 +190,15 @@ class ChangelogProcessor(Generic[ProcessorOutput], abc.ABC):
         self._fetch_next_page_called = False
         self._most_recent_results_fetch_time = None
 
-        self._results: deque[ProcessorOutput] = deque()
+        self._results: deque[ReaderOutput] = deque()
         self._metrics = FetchMetrics()
 
     @abc.abstractmethod
     def _retain(self, op: Op, decoded: ResultTupleOrDict) -> None:
-        """Retain the changelog row in the processor's internal state.
+        """Retain the changelog row in the reader's internal state.
 
-        This is used by RawChangelogProcessor to retain the full changelog result,
-        and by AppendOnlyChangelogProcessor to retain just the row data (after validating
+        This is used by ChangelogEventReader to retain the full changelog result,
+        and by AppendOnlyResultReader to retain just the row data (after validating
         that the operation is an INSERT if provided by the server).
 
         The exact retention logic is left to the concrete implementations since it may differ
@@ -206,8 +206,8 @@ class ChangelogProcessor(Generic[ProcessorOutput], abc.ABC):
         """
         raise NotImplementedError("Abstract method")  # pragma: no cover
 
-    def __iter__(self) -> ChangelogProcessor[ProcessorOutput]:
-        """Returns an iterator over the processed changelog results.
+    def __iter__(self) -> ResultReader[ReaderOutput]:
+        """Returns an iterator over the result reader results.
 
         Important: Iteration always uses blocking behavior, even in streaming mode.
         When the buffer is empty, iteration will fetch and wait for more data to
@@ -219,7 +219,7 @@ class ChangelogProcessor(Generic[ProcessorOutput], abc.ABC):
         """
         return self
 
-    def fetchone(self) -> ProcessorOutput | None:
+    def fetchone(self) -> ReaderOutput | None:
         """
         Fetch the next row from the query result.
 
@@ -233,13 +233,13 @@ class ChangelogProcessor(Generic[ProcessorOutput], abc.ABC):
             temporary emptiness (more data may come) and end of results.
 
         Note: This non-blocking behavior in streaming mode differs from iteration.
-        When iterating (for row in processor), the processor will block waiting
+        When iterating (for row in reader), the reader will block waiting
         for data. Use fetchone() in a polling loop for non-blocking streaming:
 
         Example:
             # Streaming mode polling pattern
-            while processor.may_have_results:
-                row = processor.fetchone()
+            while reader.may_have_results:
+                row = reader.fetchone()
                 if row is not None:
                     process(row)
                 else:
@@ -263,7 +263,7 @@ class ChangelogProcessor(Generic[ProcessorOutput], abc.ABC):
             raise InterfaceError("Cannot map row to dict without schema")  # pragma: no cover
         return dict(zip([col.name for col in self._statement.schema.columns], row, strict=True))
 
-    def _consume_from_buffer(self, limit: int) -> list[ProcessorOutput]:
+    def _consume_from_buffer(self, limit: int) -> list[ReaderOutput]:
         """
         Consume up to 'limit' results from the deque buffer.
 
@@ -285,7 +285,7 @@ class ChangelogProcessor(Generic[ProcessorOutput], abc.ABC):
             consumed.append(self._results.popleft())
         return consumed
 
-    def _get_next_results(self, limit: int | None) -> list[ProcessorOutput]:
+    def _get_next_results(self, limit: int | None) -> list[ReaderOutput]:
         """
         Retrieve up to `limit` results, with behavior depending on execution mode.
 
@@ -304,7 +304,7 @@ class ChangelogProcessor(Generic[ProcessorOutput], abc.ABC):
 
         Returns:
             A list of result rows (as tuples or dicts based on `as_dict` flag).
-            Behavior depends on mode and processor type.
+            Behavior depends on mode and reader type.
 
         Raises:
             InterfaceError: If limit is None and the statement is unbounded (streaming),
@@ -353,7 +353,7 @@ class ChangelogProcessor(Generic[ProcessorOutput], abc.ABC):
             or self._next_page is not None
         )
 
-    def fetchmany(self, size: int) -> list[ProcessorOutput]:
+    def fetchmany(self, size: int) -> list[ReaderOutput]:
         """
         Fetch up to 'size' rows from the query result.
 
@@ -370,8 +370,8 @@ class ChangelogProcessor(Generic[ProcessorOutput], abc.ABC):
 
         Example:
             # Streaming mode batch polling pattern
-            while processor.may_have_results:
-                batch = processor.fetchmany(100)
+            while reader.may_have_results:
+                batch = reader.fetchmany(100)
                 if batch:
                     for row in batch:
                         process(row)
@@ -394,7 +394,7 @@ class ChangelogProcessor(Generic[ProcessorOutput], abc.ABC):
 
         return self._get_next_results(size)
 
-    def fetchall(self) -> list[ProcessorOutput]:
+    def fetchall(self) -> list[ReaderOutput]:
         """
         Fetch all remaining rows of a query result.
 
@@ -426,7 +426,7 @@ class ChangelogProcessor(Generic[ProcessorOutput], abc.ABC):
 
         return self._get_next_results(None)
 
-    def __next__(self) -> ProcessorOutput:
+    def __next__(self) -> ReaderOutput:
         """Implementation of iterator protocol.
 
         This method implements blocking iteration behavior:
@@ -495,23 +495,23 @@ class ChangelogProcessor(Generic[ProcessorOutput], abc.ABC):
                 if self._as_dict:
                     decoded_row = self._map_row_to_dict(decoded_row)
 
-                # Retain the row (and perhaps also the operation) in the processor's internal state
+                # Retain the row (and perhaps also the operation) in the reader's internal state
                 self._retain(res.op, decoded_row)
 
         self._fetch_next_page_called = True
         self._most_recent_results_fetch_time = time.monotonic()
 
 
-class AppendOnlyChangelogProcessor(ChangelogProcessor[ResultTupleOrDict]):
-    """Append-only changelog processor implementation.
+class AppendOnlyResultReader(ResultReader[ResultTupleOrDict]):
+    """Append-only result reader implementation.
 
     Returns statement result rows as either tuples or dicts based on the `as_dict` flag.
     """
 
     def _retain(self, op: Op, decoded: ResultTupleOrDict) -> None:
-        """Retain the changelog row in the processor's internal state.
+        """Retain the changelog row in the reader's internal state.
 
-        For AppendOnlyChangelogProcessor, we only retain the row data (after validating
+        For AppendOnlyResultReader, we only retain the row data (after validating
         that the operation is an INSERT if provided by the server), since we only return
         the row data in fetch and iteration methods.
 
@@ -526,7 +526,7 @@ class AppendOnlyChangelogProcessor(ChangelogProcessor[ResultTupleOrDict]):
             # Only expect INSERT operations for append-only
             logger.error(f"Received non-INSERT op {op} in results for append-only statement.")
             raise NotSupportedError(
-                f"Non-INSERT op was received by AppendOnlyChangelogProcessor: {op}. "
+                f"Non-INSERT op was received by AppendOnlyResultReader: {op}. "
             )
 
         self._results.append(decoded)
@@ -534,7 +534,7 @@ class AppendOnlyChangelogProcessor(ChangelogProcessor[ResultTupleOrDict]):
 
 class ChangeloggedRow(NamedTuple):
     """Changelog operation and corresponding row data after type conversion from Results API JSON
-    to Python types. Returned by cursors using RawChangelogProcessor for non-append-only statements.
+    to Python types. Returned by cursors using ChangelogEventReader for non-append-only statements.
     """
 
     op: Op
@@ -544,8 +544,8 @@ class ChangeloggedRow(NamedTuple):
     from Results API JSON to Python types."""
 
 
-class RawChangelogProcessor(ChangelogProcessor[ChangeloggedRow]):
-    """Non-append-only changelog processor implementation.
+class ChangelogEventReader(ResultReader[ChangeloggedRow]):
+    """Non-append-only changelog event reader implementation.
 
     Returns changelog results as `ChangeloggedRow` namedtuples containing both the operation
     type (op) and the tuple or dict row data (`row`).
@@ -557,9 +557,9 @@ class RawChangelogProcessor(ChangelogProcessor[ChangeloggedRow]):
     """
 
     def _retain(self, op: Op, decoded: ResultTupleOrDict) -> None:
-        """Retain the changelog row in the processor's internal state.
+        """Retain the changelog row in the reader's internal state.
 
-        For RawChangelogProcessor, we retain both the operation type and the row data
+        For ChangelogEventReader, we retain both the operation type and the row data
 
         Args:
             op: The changelog operation type.

--- a/tests/unit/test_changelog_unit.py
+++ b/tests/unit/test_changelog_unit.py
@@ -4,30 +4,30 @@ from unittest.mock import patch
 
 import pytest
 
-from confluent_sql.changelog import (
-    AppendOnlyChangelogProcessor,
-    ChangeloggedRow,
-    FetchMetrics,
-    RawChangelogProcessor,
-)
 from confluent_sql.connection import Connection
 from confluent_sql.exceptions import InterfaceError, NotSupportedError
 from confluent_sql.execution_mode import ExecutionMode
+from confluent_sql.result_readers import (
+    AppendOnlyResultReader,
+    ChangelogEventReader,
+    ChangeloggedRow,
+    FetchMetrics,
+)
 from confluent_sql.statement import ChangelogRow, Op, Phase
 from tests.unit.conftest import StatementFactory
 
 
 @pytest.fixture
-def append_only_processor(
+def append_only_reader(
     statement_factory: StatementFactory, mock_connection: Connection
-) -> AppendOnlyChangelogProcessor:
-    """A fixture that returns an AppendOnlyChangelogProcessor instance in streaming mode."""
+) -> AppendOnlyResultReader:
+    """A fixture that returns an AppendOnlyResultReader instance in streaming mode."""
     statement = statement_factory(is_append_only=True)
-    return AppendOnlyChangelogProcessor(mock_connection, statement, ExecutionMode.STREAMING_QUERY)
+    return AppendOnlyResultReader(mock_connection, statement, ExecutionMode.STREAMING_QUERY)
 
 
 """
- Tests over AppendOnlyChangelogProcessor
+ Tests over AppendOnlyResultReader
 """
 
 
@@ -47,19 +47,19 @@ def append_only_processor(
     ],
 )
 def test_may_have_results(
-    append_only_processor: AppendOnlyChangelogProcessor,
+    append_only_reader: AppendOnlyResultReader,
     next_page_called: bool,
     remaining: int | None,
     next_page: str | None,
     expected: bool,
 ):
-    append_only_processor._fetch_next_page_called = next_page_called
+    append_only_reader._fetch_next_page_called = next_page_called
     if remaining is not None:
         # Mock some remaining results
-        append_only_processor._results = deque([("mock_row",)] * remaining)
-    append_only_processor._next_page = next_page
+        append_only_reader._results = deque([("mock_row",)] * remaining)
+    append_only_reader._next_page = next_page
 
-    assert append_only_processor.may_have_results is expected, (
+    assert append_only_reader.may_have_results is expected, (
         f"Expected may_have_results to be {expected} when"
         f" next_page_called={next_page_called}, remaining={remaining}, next_page={next_page}"
     )
@@ -67,24 +67,24 @@ def test_may_have_results(
 
 @pytest.mark.unit
 class TestFetchMethods:
-    def test_fetchmany_with_size(self, append_only_processor: AppendOnlyChangelogProcessor):
-        # Mock some results in the processor
-        append_only_processor._results = deque([("row1",), ("row2",), ("row3",)])
+    def test_fetchmany_with_size(self, append_only_reader: AppendOnlyResultReader):
+        # Mock some results in the reader
+        append_only_reader._results = deque([("row1",), ("row2",), ("row3",)])
 
         # Fetch 2 results
-        fetched = append_only_processor.fetchmany(2)
+        fetched = append_only_reader.fetchmany(2)
         assert fetched == [("row1",), ("row2",)], f"Expected to fetch 2 rows, got {fetched}"
 
         # fetch last one
-        fetched = append_only_processor.fetchmany(2)
+        fetched = append_only_reader.fetchmany(2)
         assert fetched == [("row3",)], f"Expected to fetch last row, got {fetched}"
 
-    def test_fetchmany_with_invalid_size(self, append_only_processor: AppendOnlyChangelogProcessor):
+    def test_fetchmany_with_invalid_size(self, append_only_reader: AppendOnlyResultReader):
         with pytest.raises(InterfaceError, match="size must be a positive integer"):
-            append_only_processor.fetchmany(-1)
+            append_only_reader.fetchmany(-1)
 
     def test_fetchmany_returns_buffered_results_without_fetching_new_page(
-        self, append_only_processor: AppendOnlyChangelogProcessor
+        self, append_only_reader: AppendOnlyResultReader
     ):
         """Test that fetchmany returns buffered results even if fewer than requested,
         without fetching a new page.
@@ -98,17 +98,17 @@ class TestFetchMethods:
         def mock_fetch_next_page():
             fetch_tracker["called"] = True
             # Simulate fetching more results
-            append_only_processor._results.extend([("fetched_row1",), ("fetched_row2",)])
-            append_only_processor._next_page = None
+            append_only_reader._results.extend([("fetched_row1",), ("fetched_row2",)])
+            append_only_reader._next_page = None
 
-        append_only_processor._fetch_next_page = mock_fetch_next_page
+        append_only_reader._fetch_next_page = mock_fetch_next_page
 
-        # Set up processor with 2 buffered results and indicate more pages available
-        append_only_processor._results = deque([("row1",), ("row2",)])
-        append_only_processor._next_page = "next_page_url"  # More pages available
+        # Set up reader with 2 buffered results and indicate more pages available
+        append_only_reader._results = deque([("row1",), ("row2",)])
+        append_only_reader._next_page = "next_page_url"  # More pages available
 
         # Request 5 results - more than buffered
-        fetched = append_only_processor.fetchmany(5)
+        fetched = append_only_reader.fetchmany(5)
 
         # Should return only the 2 buffered results without fetching new page
         assert fetched == [("row1",), ("row2",)], (
@@ -119,12 +119,12 @@ class TestFetchMethods:
         )
 
         # Now buffer is empty, so next fetchmany should trigger a fetch
-        fetched = append_only_processor.fetchmany(1)
+        fetched = append_only_reader.fetchmany(1)
         assert fetch_tracker["called"], "Should have fetched new page when buffer is empty"
         assert fetched == [("fetched_row1",)], f"Expected to fetch new results, got {fetched}"
 
     def test_empty_buffer_triggers_fetch_on_next_call(
-        self, append_only_processor: AppendOnlyChangelogProcessor
+        self, append_only_reader: AppendOnlyResultReader
     ):
         """Test that when the buffer is completely empty after consuming data,
         the next fetch/iteration call triggers fetching more data from the connection.
@@ -140,42 +140,42 @@ class TestFetchMethods:
         def mock_fetch_next_page():
             fetch_tracker["count"] += 1
             # Simulate fetching a new page of 2 results each time
-            append_only_processor._results.extend(
+            append_only_reader._results.extend(
                 [(f"page{fetch_tracker['count']}_row1",), (f"page{fetch_tracker['count']}_row2",)]
             )
-            append_only_processor._next_page = "next_page" if fetch_tracker["count"] < 2 else None
+            append_only_reader._next_page = "next_page" if fetch_tracker["count"] < 2 else None
 
-        append_only_processor._fetch_next_page = mock_fetch_next_page
+        append_only_reader._fetch_next_page = mock_fetch_next_page
 
         # Start with 2 buffered results
-        append_only_processor._results = deque([("initial_row1",), ("initial_row2",)])
-        append_only_processor._next_page = "next_page_url"
+        append_only_reader._results = deque([("initial_row1",), ("initial_row2",)])
+        append_only_reader._next_page = "next_page_url"
 
         # Consume all buffered data
-        result1 = append_only_processor.fetchmany(2)
+        result1 = append_only_reader.fetchmany(2)
         assert result1 == [("initial_row1",), ("initial_row2",)]
         assert fetch_tracker["count"] == 0, "Should not have fetched yet"
         # Buffer should be empty (no unconsumed rows)
-        assert len(append_only_processor._results) == 0
+        assert len(append_only_reader._results) == 0
 
         # Next fetchmany should trigger a fetch since buffer is empty
-        result2 = append_only_processor.fetchmany(1)
+        result2 = append_only_reader.fetchmany(1)
         assert fetch_tracker["count"] == 1, "Should have fetched once"
         assert result2 == [("page1_row1",)]
 
         # Consume the rest of the current buffer
-        result3 = append_only_processor.fetchone()
+        result3 = append_only_reader.fetchone()
         assert result3 == ("page1_row2",)
         # Buffer should be empty again (no unconsumed rows)
-        assert len(append_only_processor._results) == 0
+        assert len(append_only_reader._results) == 0
 
         # Another fetch should trigger another page fetch
-        result4 = append_only_processor.fetchmany(2)
+        result4 = append_only_reader.fetchmany(2)
         assert fetch_tracker["count"] == 2, "Should have fetched twice"
         assert result4 == [("page2_row1",), ("page2_row2",)]
 
     def test_fetchmany_makes_at_most_one_fetch(
-        self, append_only_processor: AppendOnlyChangelogProcessor
+        self, append_only_reader: AppendOnlyResultReader
     ):
         """Test that fetchmany makes at most one fetch request per call.
 
@@ -189,44 +189,44 @@ class TestFetchMethods:
             nonlocal fetch_count
             fetch_count += 1
             # Only return 3 rows even though more were requested
-            append_only_processor._results = deque([("row1",), ("row2",), ("row3",)])
-            append_only_processor._next_page = "more_pages"  # More pages available
+            append_only_reader._results = deque([("row1",), ("row2",), ("row3",)])
+            append_only_reader._next_page = "more_pages"  # More pages available
 
-        append_only_processor._fetch_next_page = mock_fetch_next_page
-        append_only_processor._results = deque()  # Start with empty buffer
+        append_only_reader._fetch_next_page = mock_fetch_next_page
+        append_only_reader._results = deque()  # Start with empty buffer
 
         # Request 10 results but only 3 are fetched
-        result = append_only_processor.fetchmany(10)
+        result = append_only_reader.fetchmany(10)
 
         assert fetch_count == 1, "Should have fetched exactly once"
         assert len(result) == 3, f"Should return 3 rows that were fetched, got {len(result)}"
         assert result == [("row1",), ("row2",), ("row3",)]
 
     def test_fetchmany_returns_empty_when_no_data_available(
-        self, append_only_processor: AppendOnlyChangelogProcessor
+        self, append_only_reader: AppendOnlyResultReader
     ):
         """Test that fetchmany returns empty list when no data is available."""
 
         def mock_fetch_next_page():
             # Simulate no results available
-            append_only_processor._results = deque()
-            append_only_processor._next_page = None
+            append_only_reader._results = deque()
+            append_only_reader._next_page = None
 
-        append_only_processor._fetch_next_page = mock_fetch_next_page
-        append_only_processor._results = deque()  # Empty buffer
-        append_only_processor._fetch_next_page_called = False
+        append_only_reader._fetch_next_page = mock_fetch_next_page
+        append_only_reader._results = deque()  # Empty buffer
+        append_only_reader._fetch_next_page_called = False
 
-        result = append_only_processor.fetchmany(5)
+        result = append_only_reader.fetchmany(5)
         assert result == [], "Should return empty list when no data available"
 
     def test_fetchmany_blocking_in_snapshot_mode(
         self, statement_factory: StatementFactory, mock_connection: Connection
     ):
         """Test that fetchmany uses blocking behavior in snapshot mode with
-        AppendOnlyChangelogProcessor."""
+        AppendOnlyResultReader."""
         statement = statement_factory(is_append_only=True)
-        # Create processor in SNAPSHOT mode
-        processor = AppendOnlyChangelogProcessor(mock_connection, statement, ExecutionMode.SNAPSHOT)
+        # Create reader in SNAPSHOT mode
+        reader = AppendOnlyResultReader(mock_connection, statement, ExecutionMode.SNAPSHOT)
 
         fetch_count = 0
 
@@ -235,22 +235,22 @@ class TestFetchMethods:
             fetch_count += 1
             if fetch_count == 1:
                 # First fetch returns 2 rows
-                processor._results = deque([("row1",), ("row2",)])
-                processor._next_page = "page2"
+                reader._results = deque([("row1",), ("row2",)])
+                reader._next_page = "page2"
             elif fetch_count == 2:
                 # Second fetch returns 2 more rows
-                processor._results.extend([("row3",), ("row4",)])
-                processor._next_page = "page3"
+                reader._results.extend([("row3",), ("row4",)])
+                reader._next_page = "page3"
             elif fetch_count == 3:
                 # Third fetch returns 1 row
-                processor._results.extend([("row5",)])
-                processor._next_page = None
+                reader._results.extend([("row5",)])
+                reader._next_page = None
 
-        processor._fetch_next_page = mock_fetch_next_page
-        processor._results = deque()
+        reader._fetch_next_page = mock_fetch_next_page
+        reader._results = deque()
 
         # Request 5 results - should fetch multiple pages to fulfill request
-        result = processor.fetchmany(5)
+        result = reader.fetchmany(5)
 
         # In snapshot mode, it should have fetched 3 times to get 5 rows
         assert fetch_count == 3, f"Should have fetched 3 times in snapshot mode, got {fetch_count}"
@@ -261,10 +261,10 @@ class TestFetchMethods:
         self, statement_factory: StatementFactory, mock_connection: Connection
     ):
         """Test that fetchmany uses non-blocking behavior in streaming mode even with
-        AppendOnlyChangelogProcessor."""
+        AppendOnlyResultReader."""
         statement = statement_factory(is_append_only=True)
-        # Create processor in STREAMING_QUERY mode
-        processor = AppendOnlyChangelogProcessor(
+        # Create reader in STREAMING_QUERY mode
+        reader = AppendOnlyResultReader(
             mock_connection, statement, ExecutionMode.STREAMING_QUERY
         )
 
@@ -274,14 +274,14 @@ class TestFetchMethods:
             nonlocal fetch_count
             fetch_count += 1
             # Only return 3 rows even though 5 were requested
-            processor._results = deque([("row1",), ("row2",), ("row3",)])
-            processor._next_page = "more_pages"
+            reader._results = deque([("row1",), ("row2",), ("row3",)])
+            reader._next_page = "more_pages"
 
-        processor._fetch_next_page = mock_fetch_next_page
-        processor._results = deque()
+        reader._fetch_next_page = mock_fetch_next_page
+        reader._results = deque()
 
         # Request 5 results - should only fetch once in streaming mode
-        result = processor.fetchmany(5)
+        result = reader.fetchmany(5)
 
         # In streaming mode, it should fetch only once
         assert fetch_count == 1, (
@@ -291,11 +291,11 @@ class TestFetchMethods:
         assert result == [("row1",), ("row2",), ("row3",)]
 
     def test_may_have_results_distinguishes_temporary_vs_permanent_emptiness(
-        self, append_only_processor: AppendOnlyChangelogProcessor
+        self, append_only_reader: AppendOnlyResultReader
     ):
         """Test that may_have_results helps distinguish between temporary and permanent emptiness"""
         # Initially, no results fetched yet
-        assert append_only_processor.may_have_results is True, (
+        assert append_only_reader.may_have_results is True, (
             "Should indicate may have results initially"
         )
 
@@ -307,31 +307,31 @@ class TestFetchMethods:
             fetch_count += 1
             if fetch_count == 1:
                 # First fetch: no data yet, but more pages available
-                append_only_processor._results = deque()
-                append_only_processor._next_page = "more_coming"
-                append_only_processor._fetch_next_page_called = True
+                append_only_reader._results = deque()
+                append_only_reader._next_page = "more_coming"
+                append_only_reader._fetch_next_page_called = True
             elif fetch_count == 2:
                 # Second fetch: some data arrives
-                append_only_processor._results = deque([("row1",)])
-                append_only_processor._next_page = None  # No more pages
+                append_only_reader._results = deque([("row1",)])
+                append_only_reader._next_page = None  # No more pages
 
-        append_only_processor._fetch_next_page = mock_fetch_next_page
+        append_only_reader._fetch_next_page = mock_fetch_next_page
 
         # First fetchone - no data yet but more may come
-        result = append_only_processor.fetchone()
+        result = append_only_reader.fetchone()
         assert result is None, "Should return None when no data available"
-        assert append_only_processor.may_have_results is True, (
+        assert append_only_reader.may_have_results is True, (
             "Should still indicate may have results when temporary empty"
         )
 
         # Second fetchone - data arrives
-        result = append_only_processor.fetchone()
+        result = append_only_reader.fetchone()
         assert result == ("row1",), "Should return the row"
 
         # Third fetchone - permanently empty now
-        result = append_only_processor.fetchone()
+        result = append_only_reader.fetchone()
         assert result is None, "Should return None when no more data"
-        assert append_only_processor.may_have_results is False, (
+        assert append_only_reader.may_have_results is False, (
             "Should indicate no more results when permanently empty"
         )
 
@@ -340,8 +340,8 @@ class TestFetchMethods:
     ):
         """Test that fetchone() makes at most one fetch per call in streaming mode."""
         statement = statement_factory(is_append_only=True)
-        # Create processor in STREAMING_QUERY mode
-        processor = AppendOnlyChangelogProcessor(
+        # Create reader in STREAMING_QUERY mode
+        reader = AppendOnlyResultReader(
             mock_connection, statement, ExecutionMode.STREAMING_QUERY
         )
 
@@ -352,37 +352,37 @@ class TestFetchMethods:
             fetch_count += 1
             # First fetch returns one row
             if fetch_count == 1:
-                processor._results = deque([("row1",)])
-                processor._next_page = None  # No more pages
-                processor._fetch_next_page_called = True
+                reader._results = deque([("row1",)])
+                reader._next_page = None  # No more pages
+                reader._fetch_next_page_called = True
             else:
                 # Should not be called more than once per fetchone() call
-                processor._results = deque()
-                processor._next_page = None
-                processor._fetch_next_page_called = True
+                reader._results = deque()
+                reader._next_page = None
+                reader._fetch_next_page_called = True
 
-        processor._fetch_next_page = mock_fetch_next_page
-        processor._results = deque()  # Start with empty buffer
+        reader._fetch_next_page = mock_fetch_next_page
+        reader._results = deque()  # Start with empty buffer
 
         # First fetchone() - should fetch once and return row1
-        result = processor.fetchone()
+        result = reader.fetchone()
 
         assert fetch_count == 1, "Should have fetched exactly once"
         assert result == ("row1",), "Should return the fetched row"
-        assert processor.may_have_results is False, "No more results (next_page is None)"
+        assert reader.may_have_results is False, "No more results (next_page is None)"
 
         # Second fetchone() - buffer empty, no next page, should NOT fetch
         fetch_count = 0  # Reset counter to verify no fetch happens
-        result = processor.fetchone()
+        result = reader.fetchone()
 
         assert fetch_count == 0, "Should NOT fetch when no next page available"
         assert result is None, "Should return None when no data"
-        assert processor.may_have_results is False, "Should indicate no more results"
+        assert reader.may_have_results is False, "Should indicate no more results"
 
         # Test scenario with more pages available
         # Reset for a new scenario
-        processor._next_page = "more_pages"  # Simulate more pages
-        processor._results = deque()
+        reader._next_page = "more_pages"  # Simulate more pages
+        reader._results = deque()
 
         # Create a new mock that tracks this specific call
         third_call_fetch_count = 0
@@ -390,77 +390,77 @@ class TestFetchMethods:
         def mock_fetch_for_third_call():
             nonlocal third_call_fetch_count
             third_call_fetch_count += 1
-            processor._results = deque()  # Return empty results this time
-            processor._next_page = None
-            processor._fetch_next_page_called = True
+            reader._results = deque()  # Return empty results this time
+            reader._next_page = None
+            reader._fetch_next_page_called = True
 
-        processor._fetch_next_page = mock_fetch_for_third_call
+        reader._fetch_next_page = mock_fetch_for_third_call
 
         # This fetchone() SHOULD fetch because there are more pages
-        result = processor.fetchone()
+        result = reader.fetchone()
 
         assert third_call_fetch_count == 1, "Should fetch once when more pages are available"
         assert result is None, "Returns None when fetch yields no data"
-        assert processor.may_have_results is False, "No more results after fetch"
+        assert reader.may_have_results is False, "No more results after fetch"
 
-    def test_fetchone(self, append_only_processor: AppendOnlyChangelogProcessor):
-        # Mock some results in the processor
-        append_only_processor._results = deque([("row1",), ("row2",)])
+    def test_fetchone(self, append_only_reader: AppendOnlyResultReader):
+        # Mock some results in the reader
+        append_only_reader._results = deque([("row1",), ("row2",)])
 
         # Fetch one result
-        fetched = append_only_processor.fetchone()
+        fetched = append_only_reader.fetchone()
         assert fetched == ("row1",), f"Expected to fetch first row, got {fetched}"
 
         # Fetch next result
-        fetched = append_only_processor.fetchone()
+        fetched = append_only_reader.fetchone()
         assert fetched == ("row2",), f"Expected to fetch second row, got {fetched}"
 
         # Fetch when no more results are available
-        fetched = append_only_processor.fetchone()
+        fetched = append_only_reader.fetchone()
         assert fetched is None, f"Expected to fetch None when no more results, got {fetched}"
 
     def test_fetchall_against_bounded_statement(
-        self, append_only_processor: AppendOnlyChangelogProcessor
+        self, append_only_reader: AppendOnlyResultReader
     ):
         # By default the statement from the fixture should be bounded.
-        assert append_only_processor._statement.is_bounded, (
+        assert append_only_reader._statement.is_bounded, (
             "Statement should be bounded for this test"
         )
 
-        # Mock some results in the processor
-        append_only_processor._results = deque([("row1",), ("row2",), ("row3",)])
+        # Mock some results in the reader
+        append_only_reader._results = deque([("row1",), ("row2",), ("row3",)])
 
         # Fetch all results
-        fetched = append_only_processor.fetchall()
+        fetched = append_only_reader.fetchall()
         assert fetched == [("row1",), ("row2",), ("row3",)], (
             f"Expected to fetch all rows, got {fetched}"
         )
 
     def test_fetchall_vs_streaming_results(
-        self, append_only_processor: AppendOnlyChangelogProcessor
+        self, append_only_reader: AppendOnlyResultReader
     ):
-        # Doctor the processor's statement to have come from a streaming query
-        append_only_processor._statement.traits.is_bounded = False  # type: ignore
+        # Doctor the reader's statement to have come from a streaming query
+        append_only_reader._statement.traits.is_bounded = False  # type: ignore
 
         # fetchall should raise an error when used against an unbounded/streaming query
         with pytest.raises(
             NotSupportedError,
             match=re.escape("Cannot call fetchall() on an unbounded streaming statement"),
         ):
-            append_only_processor.fetchall()
+            append_only_reader.fetchall()
 
 
 @pytest.mark.unit
 class TestIteration:
     def test_iteration_over_onhand_results(
-        self, append_only_processor: AppendOnlyChangelogProcessor
+        self, append_only_reader: AppendOnlyResultReader
     ):
-        # Mock some results in the processor
-        append_only_processor._results = deque([("row1",), ("row2",), ("row3",)])
+        # Mock some results in the reader
+        append_only_reader._results = deque([("row1",), ("row2",), ("row3",)])
 
-        # Iterate over the processor and collect results
+        # Iterate over the reader and collect results
         collected = []
-        for row in append_only_processor:
+        for row in append_only_reader:
             collected.append(row)
 
         assert collected == [("row1",), ("row2",), ("row3",)], (
@@ -468,7 +468,7 @@ class TestIteration:
         )
 
     def test_iteration_calls_fetch_next_page(
-        self, append_only_processor: AppendOnlyChangelogProcessor
+        self, append_only_reader: AppendOnlyResultReader
     ):
         # Mock the _fetch_next_page method to track calls
         call_tracker = {"called": False}
@@ -476,15 +476,15 @@ class TestIteration:
         def mock_fetch_next_page():
             call_tracker["called"] = True
             # Simulate fetching a page of results
-            append_only_processor._results = deque([("fetched_row1",), ("fetched_row2",)])
-            append_only_processor._next_page = None  # No more pages after this
-            append_only_processor._fetch_next_page_called = True  # Mark that fetch was called
+            append_only_reader._results = deque([("fetched_row1",), ("fetched_row2",)])
+            append_only_reader._next_page = None  # No more pages after this
+            append_only_reader._fetch_next_page_called = True  # Mark that fetch was called
 
-        append_only_processor._fetch_next_page = mock_fetch_next_page
+        append_only_reader._fetch_next_page = mock_fetch_next_page
 
-        # Iterate over the processor to trigger fetching
+        # Iterate over the reader to trigger fetching
         collected = []
-        for row in append_only_processor:
+        for row in append_only_reader:
             collected.append(row)
 
         assert call_tracker["called"], (
@@ -495,19 +495,19 @@ class TestIteration:
         )
 
     def test_iteration_stops_when_no_more_results(
-        self, append_only_processor: AppendOnlyChangelogProcessor
+        self, append_only_reader: AppendOnlyResultReader
     ):
         # Mock the _fetch_next_page method to simulate no results and no next page
         def mock_fetch_next_page():
-            append_only_processor._results = deque()
-            append_only_processor._next_page = None
-            append_only_processor._fetch_next_page_called = True  # Mark that fetch was called
+            append_only_reader._results = deque()
+            append_only_reader._next_page = None
+            append_only_reader._fetch_next_page_called = True  # Mark that fetch was called
 
-        append_only_processor._fetch_next_page = mock_fetch_next_page
+        append_only_reader._fetch_next_page = mock_fetch_next_page
 
-        # Iterate over the processor and collect results
+        # Iterate over the reader and collect results
         collected = []
-        for row in append_only_processor:
+        for row in append_only_reader:
             collected.append(row)
 
         assert collected == [], f"Expected to collect no rows, got {collected}"
@@ -515,24 +515,24 @@ class TestIteration:
     def test_iteration_with_dict_mode(
         self, statement_factory: StatementFactory, mock_connection: Connection
     ):
-        # Create a processor with as_dict=True. By default, the statement factory
+        # Create a reader with as_dict=True. By default, the statement factory
         # creates a statement with a simple schema that has one column named "value".
         statement = statement_factory(is_append_only=True)
-        processor = AppendOnlyChangelogProcessor(
+        reader = AppendOnlyResultReader(
             mock_connection, statement, ExecutionMode.STREAMING_QUERY, as_dict=True
         )
 
         # Mock the _fetch_next_page method to simulate fetching results
         def mock_fetch_next_page():
-            processor._results = deque([{"value": "row1"}, {"value": "row2"}])
-            processor._next_page = None
-            processor._fetch_next_page_called = True  # Mark that fetch was called
+            reader._results = deque([{"value": "row1"}, {"value": "row2"}])
+            reader._next_page = None
+            reader._fetch_next_page_called = True  # Mark that fetch was called
 
-        processor._fetch_next_page = mock_fetch_next_page
+        reader._fetch_next_page = mock_fetch_next_page
 
-        # Iterate over the processor and collect results
+        # Iterate over the reader and collect results
         collected = []
-        for row in processor:
+        for row in reader:
             collected.append(row)
 
         expected_collected = [
@@ -547,26 +547,26 @@ class TestIteration:
 @pytest.mark.unit
 class TestFetchNextPage:
     def test_raises_if_statement_not_ready(
-        self, append_only_processor: AppendOnlyChangelogProcessor
+        self, append_only_reader: AppendOnlyResultReader
     ):
         # Append-only statements in streaming mode are ready when RUNNING.
         # But a statement in PENDING phase is never ready, so test that instead.
-        append_only_processor._statement._phase = Phase.PENDING
+        append_only_reader._statement._phase = Phase.PENDING
 
         with pytest.raises(InterfaceError, match="Statement is not ready"):
-            append_only_processor._fetch_next_page()
+            append_only_reader._fetch_next_page()
 
-    def test_raises_if_no_schema(self, append_only_processor: AppendOnlyChangelogProcessor):
-        # Doctor the processor's statement to have no schema
-        append_only_processor._statement.traits.schema = None  # type: ignore
+    def test_raises_if_no_schema(self, append_only_reader: AppendOnlyResultReader):
+        # Doctor the reader's statement to have no schema
+        append_only_reader._statement.traits.schema = None  # type: ignore
 
         with pytest.raises(
             InterfaceError, match="Trying to fetch results for a non-query statement"
         ):
-            append_only_processor._fetch_next_page()
+            append_only_reader._fetch_next_page()
 
     def test_calls_next_page_if_zero_results_onhand(
-        self, append_only_processor: AppendOnlyChangelogProcessor
+        self, append_only_reader: AppendOnlyResultReader
     ):
         # Mock the connection's _get_statement_results to track calls and return some results
         call_tracker = {"called": False}
@@ -583,37 +583,37 @@ class TestFetchNextPage:
                 ChangelogRow(0, ["false"]),
             ], None  # Mock some results and no next page
 
-        append_only_processor._connection._get_statement_results = mock_get_statement_results
+        append_only_reader._connection._get_statement_results = mock_get_statement_results
 
-        # Ensure processor has no on-hand results to trigger fetching
-        append_only_processor._results = deque()
-        append_only_processor._next_page = None
+        # Ensure reader has no on-hand results to trigger fetching
+        append_only_reader._results = deque()
+        append_only_reader._next_page = None
 
         # Call _fetch_next_page and check that it called the connection method and processed results
-        append_only_processor._fetch_next_page()
+        append_only_reader._fetch_next_page()
 
         assert call_tracker["called"], "Expected _get_statement_results to have been called"
-        assert append_only_processor._results == deque([(True,), (False,)]), (
-            "Expected fetched results to be stored in processor"
+        assert append_only_reader._results == deque([(True,), (False,)]), (
+            "Expected fetched results to be stored in reader"
         )
 
     def test_fetch_next_page_called_during_iteration(
-        self, append_only_processor: AppendOnlyChangelogProcessor
+        self, append_only_reader: AppendOnlyResultReader
     ):
         # Mock the _fetch_next_page method to track calls and simulate fetching results
         call_tracker = {"called": False}
 
         def mock_fetch_next_page():
             call_tracker["called"] = True
-            append_only_processor._results = deque([("fetched_row1",), ("fetched_row2",)])
-            append_only_processor._next_page = None
-            append_only_processor._fetch_next_page_called = True  # Mark that fetch was called
+            append_only_reader._results = deque([("fetched_row1",), ("fetched_row2",)])
+            append_only_reader._next_page = None
+            append_only_reader._fetch_next_page_called = True  # Mark that fetch was called
 
-        append_only_processor._fetch_next_page = mock_fetch_next_page
+        append_only_reader._fetch_next_page = mock_fetch_next_page
 
-        # Iterate over the processor to trigger fetching
+        # Iterate over the reader to trigger fetching
         collected = []
-        for row in append_only_processor:
+        for row in append_only_reader:
             collected.append(row)
 
         assert call_tracker["called"], (
@@ -624,9 +624,9 @@ class TestFetchNextPage:
         )
 
     def test_raises_if_non_insert_op_in_append_only_results(
-        self, append_only_processor: AppendOnlyChangelogProcessor
+        self, append_only_reader: AppendOnlyResultReader
     ):
-        """append-only changelog processor should raise if it encounters a non-INSERT op in results
+        """append-only result reader should raise if it encounters a non-INSERT op in results
         from the server, since that violates the contract of append-only statements."""
 
         def mock_get_statement_results(
@@ -636,47 +636,47 @@ class TestFetchNextPage:
                 ChangelogRow(Op.DELETE.value, ["value"])
             ], None  # Mock a non-INSERT op in results
 
-        append_only_processor._connection._get_statement_results = mock_get_statement_results
+        append_only_reader._connection._get_statement_results = mock_get_statement_results
 
-        # Ensure processor has no on-hand results to trigger fetching
-        append_only_processor._results = deque()
-        append_only_processor._next_page = None
+        # Ensure reader has no on-hand results to trigger fetching
+        append_only_reader._results = deque()
+        append_only_reader._next_page = None
 
         with pytest.raises(NotSupportedError, match="Non-INSERT op"):
-            append_only_processor._fetch_next_page()
+            append_only_reader._fetch_next_page()
 
 
 @pytest.fixture
-def raw_changelog_processor(
+def changelog_event_reader(
     statement_factory: StatementFactory, mock_connection: Connection
-) -> RawChangelogProcessor:
-    """A fixture that returns a RawChangelogProcessor instance in streaming mode."""
+) -> ChangelogEventReader:
+    """A fixture that returns a ChangelogEventReader instance in streaming mode."""
     statement = statement_factory(is_append_only=False)
-    return RawChangelogProcessor(mock_connection, statement, ExecutionMode.STREAMING_QUERY)
+    return ChangelogEventReader(mock_connection, statement, ExecutionMode.STREAMING_QUERY)
 
 
 @pytest.mark.unit
-class TestRawChangelogProcessor:
+class TestChangelogEventReader:
     """
-    Tests over RawChangelogProcessor. Only material difference
-    between this and AppendOnlyChangelogProcessor is that the _retain method in this class
+    Tests over ChangelogEventReader. Only material difference
+    between this and AppendOnlyResultReader is that the _retain method in this class
     converts retained rows into ChangeloggedRow named tuples that include the changelog operation
     type, so we focus tests on that behavior here.
     """
 
     def test_retain_converts_to_changelogged_row(
-        self, raw_changelog_processor: RawChangelogProcessor
+        self, changelog_event_reader: ChangelogEventReader
     ):
         # Call _retain a couple of times -- first with an INSERT op, then with a DELETE op.
 
-        raw_changelog_processor._retain(
+        changelog_event_reader._retain(
             Op.INSERT, ("value1", 123, "true")
         )  # Mock an INSERT op with some values
 
-        raw_changelog_processor._retain(Op.DELETE, ("value1", 123, "true"))
+        changelog_event_reader._retain(Op.DELETE, ("value1", 123, "true"))
 
         # Fetch the first retained row and check that it's a ChangeloggedRow with expected values
-        v = raw_changelog_processor.fetchone()
+        v = changelog_event_reader.fetchone()
         assert isinstance(v, ChangeloggedRow), (
             f"Expected fetched row to be a ChangeloggedRow, got {type(v)}"
         )
@@ -684,20 +684,20 @@ class TestRawChangelogProcessor:
         assert v.row == ("value1", 123, "true"), f"Expected row data to be unchanged, got {v.row}"
 
         # Fetch the second retained row and check that it's a ChangeloggedRow with expected values
-        v = raw_changelog_processor.fetchone()
+        v = changelog_event_reader.fetchone()
         assert isinstance(v, ChangeloggedRow), (
             f"Expected fetched row to be a ChangeloggedRow, got {type(v)}"
         )
         assert v.op == Op.DELETE, f"Expected op to be Op.DELETE, got {v.op}"
         assert v.row == ("value1", 123, "true"), f"Expected row data to be unchanged, got {v.row}"
 
-    def test_raw_processor_blocking_in_snapshot_mode(
+    def test_changelog_event_reader_blocking_in_snapshot_mode(
         self, statement_factory: StatementFactory, mock_connection: Connection
     ):
-        """Test that RawChangelogProcessor also uses blocking behavior in snapshot mode."""
+        """Test that ChangelogEventReader also uses blocking behavior in snapshot mode."""
         statement = statement_factory(is_append_only=False)
-        # Create processor in SNAPSHOT mode
-        processor = RawChangelogProcessor(mock_connection, statement, ExecutionMode.SNAPSHOT)
+        # Create reader in SNAPSHOT mode
+        reader = ChangelogEventReader(mock_connection, statement, ExecutionMode.SNAPSHOT)
 
         fetch_count = 0
 
@@ -706,26 +706,26 @@ class TestRawChangelogProcessor:
             fetch_count += 1
             if fetch_count == 1:
                 # First fetch returns 2 changelog rows
-                processor._results = deque([
+                reader._results = deque([
                     ChangeloggedRow(Op.INSERT, ("row1",)),
                     ChangeloggedRow(Op.UPDATE_BEFORE, ("row2",)),
                 ])
-                processor._next_page = "page2"
+                reader._next_page = "page2"
             elif fetch_count == 2:
                 # Second fetch returns 2 more changelog rows
-                processor._results.extend(
+                reader._results.extend(
                     [
                         ChangeloggedRow(Op.UPDATE_AFTER, ("row2_updated",)),
                         ChangeloggedRow(Op.DELETE, ("row3",)),
                     ]
                 )
-                processor._next_page = None
+                reader._next_page = None
 
-        processor._fetch_next_page = mock_fetch_next_page
-        processor._results = deque()
+        reader._fetch_next_page = mock_fetch_next_page
+        reader._results = deque()
 
         # Request 4 results - should fetch multiple pages to fulfill request
-        result = processor.fetchmany(4)
+        result = reader.fetchmany(4)
 
         # In snapshot mode, it should have fetched 2 times to get 4 rows
         assert fetch_count == 2, f"Should have fetched 2 times in snapshot mode, got {fetch_count}"
@@ -737,9 +737,9 @@ class TestRawChangelogProcessor:
 class TestFetchMetrics:
     """Tests for FetchMetrics collection and the metrics property."""
 
-    def test_metrics_initialized_to_zero(self, append_only_processor: AppendOnlyChangelogProcessor):
+    def test_metrics_initialized_to_zero(self, append_only_reader: AppendOnlyResultReader):
         """Test that metrics are initialized with zero values."""
-        metrics = append_only_processor.metrics
+        metrics = append_only_reader.metrics
 
         assert isinstance(metrics, FetchMetrics)
         assert metrics.total_page_fetches == 0
@@ -751,7 +751,7 @@ class TestFetchMetrics:
         assert metrics.avg_rows_per_page == pytest.approx(0.0)
 
     def test_metrics_updated_during_fetch(
-        self, append_only_processor: AppendOnlyChangelogProcessor
+        self, append_only_reader: AppendOnlyResultReader
     ):
         """Test that metrics are properly updated when fetching pages."""
 
@@ -766,28 +766,28 @@ class TestFetchMetrics:
                 ChangelogRow(Op.INSERT.value, ["value3"]),
             ], None
 
-        append_only_processor._connection._get_statement_results = mock_get_statement_results
+        append_only_reader._connection._get_statement_results = mock_get_statement_results
 
-        # Ensure processor starts with no results
-        append_only_processor._results = deque()
+        # Ensure reader starts with no results
+        append_only_reader._results = deque()
 
         # Fetch a page
         # Need 3 time.monotonic() calls: prep_for_fetch, record_fetch_completion,
         # and setting _most_recent_results_fetch_time
         with patch("time.monotonic", side_effect=[100.0, 100.5, 100.5]):
-            append_only_processor._fetch_next_page()
+            append_only_reader._fetch_next_page()
 
-        metrics = append_only_processor.metrics
+        metrics = append_only_reader.metrics
         assert metrics.total_page_fetches == 1
         assert metrics.total_changelog_rows_fetched == 3
         assert metrics.empty_page_fetches == 0
         assert metrics.fetch_request_secs == pytest.approx(0.5)
         assert metrics.avg_rows_per_page == pytest.approx(3.0)
 
-    def test_metrics_with_pausing(self, append_only_processor: AppendOnlyChangelogProcessor):
+    def test_metrics_with_pausing(self, append_only_reader: AppendOnlyResultReader):
         """Test that pausing metrics are tracked correctly."""
         # Set up connection pause time
-        append_only_processor._connection.statement_results_page_fetch_pause_secs = 2.0
+        append_only_reader._connection.statement_results_page_fetch_pause_secs = 2.0
 
         # Mock get_statement_results to return some rows
         def mock_get_statement_results(
@@ -795,12 +795,12 @@ class TestFetchMetrics:
         ) -> tuple[list[ChangelogRow], str | None]:
             return [ChangelogRow(Op.INSERT.value, ["value1"])], None
 
-        append_only_processor._connection._get_statement_results = mock_get_statement_results
+        append_only_reader._connection._get_statement_results = mock_get_statement_results
 
         # Set up state as if we had fetched before (to trigger pause logic)
-        append_only_processor._results = deque()
-        append_only_processor._most_recent_results_fetch_time = 99.0  # Previous fetch time
-        append_only_processor._fetch_next_page_called = True
+        append_only_reader._results = deque()
+        append_only_reader._most_recent_results_fetch_time = 99.0  # Previous fetch time
+        append_only_reader._fetch_next_page_called = True
 
         # Mock time to simulate: current time is 99.5, so only 0.5 seconds elapsed
         # This means we need to pause for 1.5 seconds (2.0 - 0.5)
@@ -810,16 +810,16 @@ class TestFetchMetrics:
             patch("time.monotonic", side_effect=[99.5, 100.0, 100.1, 100.1]),
             patch("time.sleep") as mock_sleep,
         ):
-            append_only_processor._fetch_next_page()
+            append_only_reader._fetch_next_page()
             mock_sleep.assert_called_once_with(1.5)
 
-        metrics = append_only_processor.metrics
+        metrics = append_only_reader.metrics
         assert metrics.paused_times == 1
         assert metrics.paused_secs == pytest.approx(1.5)
         assert metrics.total_page_fetches == 1
         assert metrics.fetch_request_secs == pytest.approx(0.1)  # 100.1 - 100.0
 
-    def test_metrics_empty_page_fetch(self, append_only_processor: AppendOnlyChangelogProcessor):
+    def test_metrics_empty_page_fetch(self, append_only_reader: AppendOnlyResultReader):
         """Test that empty page fetches are tracked."""
 
         # Mock to return empty results
@@ -828,20 +828,20 @@ class TestFetchMetrics:
         ) -> tuple[list[ChangelogRow], str | None]:
             return [], None  # Empty page
 
-        append_only_processor._connection._get_statement_results = mock_get_statement_results
-        append_only_processor._results = deque()
+        append_only_reader._connection._get_statement_results = mock_get_statement_results
+        append_only_reader._results = deque()
 
         with patch("time.monotonic", side_effect=[100.0, 100.2, 100.2]):
-            append_only_processor._fetch_next_page()
+            append_only_reader._fetch_next_page()
 
-        metrics = append_only_processor.metrics
+        metrics = append_only_reader.metrics
         assert metrics.total_page_fetches == 1
         assert metrics.total_changelog_rows_fetched == 0
         assert metrics.empty_page_fetches == 1
         assert metrics.avg_rows_per_page == pytest.approx(0.0)
 
     def test_metrics_accumulate_across_multiple_fetches(
-        self, append_only_processor: AppendOnlyChangelogProcessor
+        self, append_only_reader: AppendOnlyResultReader
     ):
         """Test that metrics accumulate correctly across multiple fetch operations."""
         fetch_count = 0
@@ -868,33 +868,33 @@ class TestFetchMetrics:
                 # Third fetch: empty
                 return [], None
 
-        append_only_processor._connection._get_statement_results = mock_get_statement_results
-        append_only_processor._connection.statement_results_page_fetch_pause_secs = (
+        append_only_reader._connection._get_statement_results = mock_get_statement_results
+        append_only_reader._connection.statement_results_page_fetch_pause_secs = (
             0  # No pausing for this test
         )
-        append_only_processor._results = deque()
+        append_only_reader._results = deque()
 
         # Perform three fetches
         with patch("time.monotonic", side_effect=[100.0, 100.1, 100.1]):  # First fetch
-            append_only_processor._fetch_next_page()
+            append_only_reader._fetch_next_page()
 
         # Clear results to trigger next fetch
-        append_only_processor._results = deque()
-        append_only_processor._most_recent_results_fetch_time = 100.1
+        append_only_reader._results = deque()
+        append_only_reader._most_recent_results_fetch_time = 100.1
 
         # Second fetch (check elapsed, prep, complete, set time)
         with patch("time.monotonic", side_effect=[101.0, 101.0, 101.2, 101.2]):
-            append_only_processor._fetch_next_page()
+            append_only_reader._fetch_next_page()
 
         # Clear results to trigger next fetch
-        append_only_processor._results = deque()
-        append_only_processor._most_recent_results_fetch_time = 101.2
+        append_only_reader._results = deque()
+        append_only_reader._most_recent_results_fetch_time = 101.2
 
         # Third fetch (empty)
         with patch("time.monotonic", side_effect=[102.0, 102.0, 102.05, 102.05]):
-            append_only_processor._fetch_next_page()
+            append_only_reader._fetch_next_page()
 
-        metrics = append_only_processor.metrics
+        metrics = append_only_reader.metrics
         assert metrics.total_page_fetches == 3
         assert metrics.total_changelog_rows_fetched == 5  # 2 + 3 + 0
         assert metrics.empty_page_fetches == 1  # Only the third fetch was empty

--- a/tests/unit/test_cursor_unit.py
+++ b/tests/unit/test_cursor_unit.py
@@ -3,7 +3,6 @@ import re
 import pytest
 
 from confluent_sql import Cursor, InterfaceError
-from confluent_sql.changelog import ChangeloggedRow, FetchMetrics, RawChangelogProcessor
 from confluent_sql.exceptions import (
     ComputePoolExhaustedError,
     NotSupportedError,
@@ -11,6 +10,7 @@ from confluent_sql.exceptions import (
     ProgrammingError,
 )
 from confluent_sql.execution_mode import ExecutionMode
+from confluent_sql.result_readers import ChangelogEventReader, ChangeloggedRow, FetchMetrics
 from confluent_sql.statement import ChangelogRow, Op, Statement
 from tests.unit.conftest import MockConnectionFactory, ResultRowFactory, StatementResponseFactory
 
@@ -83,9 +83,9 @@ class TestExecute:
 
         mock_connection_cursor.execute("SELECT 1 AS col")
 
-        # Prove that we set the changelog processor to a RawChangelogProcessor, which can handle
+        # Prove that we set the result reader to a ChangelogEventReader, which can handle
         # non-append-only statements.
-        assert isinstance(mock_connection_cursor._changelog_processor, RawChangelogProcessor)
+        assert isinstance(mock_connection_cursor._result_reader, ChangelogEventReader)
 
     def test_execute_calls_raise_if_statement_is_broken_for_failed_statement(
         self,
@@ -609,45 +609,45 @@ class TestFetchMany:
         expected_arraysize = 5
         mock_connection_cursor.arraysize = expected_arraysize
 
-        changelog_processor_mock = mocker.Mock()
-        changelog_processor_mock.fetchmany.return_value = []
+        result_reader_mock = mocker.Mock()
+        result_reader_mock.fetchmany.return_value = []
         mocker.patch.object(
             mock_connection_cursor,
-            "_get_changelog_processor",
-            return_value=changelog_processor_mock,
+            "_get_result_reader",
+            return_value=result_reader_mock,
         )
 
         mock_connection_cursor.fetchmany()
-        changelog_processor_mock.fetchmany.assert_called_once_with(expected_arraysize)  # type: ignore
+        result_reader_mock.fetchmany.assert_called_once_with(expected_arraysize)  # type: ignore
 
     def test_fetchmany_returns_buffered_rows_even_if_fewer_than_requested(
         self, mock_connection_cursor: Cursor, mocker
     ):
         """Test that fetchmany returns only buffered rows without fetching new pages.
 
-        When the cursor's changelog processor has 3 rows cached and fetchmany(5)
+        When the cursor's result reader has 3 rows cached and fetchmany(5)
         is called, only the 3 cached rows should be returned without triggering
         a new page fetch.
         """
-        # Create mock changelog processor with 3 cached rows
-        changelog_processor_mock = mocker.Mock()
+        # Create mock result reader with 3 cached rows
+        result_reader_mock = mocker.Mock()
 
-        # The processor will return 3 rows when fetchmany(5) is called
+        # The reader will return 3 rows when fetchmany(5) is called
         cached_rows = [("row1",), ("row2",), ("row3",)]
-        changelog_processor_mock.fetchmany.return_value = cached_rows
+        result_reader_mock.fetchmany.return_value = cached_rows
 
-        # Mock the _get_changelog_processor to return our mock processor
+        # Mock the _get_result_reader to return our mock reader
         mocker.patch.object(
             mock_connection_cursor,
-            "_get_changelog_processor",
-            return_value=changelog_processor_mock,
+            "_get_result_reader",
+            return_value=result_reader_mock,
         )
 
         # Request 5 rows but only 3 are cached
         result = mock_connection_cursor.fetchmany(size=5)
 
-        # Verify that fetchmany was called with size=5 on the processor
-        changelog_processor_mock.fetchmany.assert_called_once_with(5)
+        # Verify that fetchmany was called with size=5 on the reader
+        result_reader_mock.fetchmany.assert_called_once_with(5)
 
         # Verify that only 3 rows were returned (the cached ones)
         assert result == cached_rows, (
@@ -817,7 +817,7 @@ class TestCursorFetching:
 
         # By default, statement_response_factory() will return an append-only
         # statement response, which is what we want for this test. The associated
-        # AppendOnlyChangelogProcessor will raise if it receives non-INSERT ops.
+        # AppendOnlyResultReader will raise if it receives non-INSERT ops.
 
         # Statement columns needs to match the result rows being returned.
         statement_response = statement_response_factory(
@@ -857,7 +857,7 @@ class TestCursorFetching:
 
         with pytest.raises(
             NotSupportedError,
-            match="Non-INSERT op was received by AppendOnlyChangelogProcessor",
+            match="Non-INSERT op was received by AppendOnlyResultReader",
         ):
             cursor.fetchone()
 
@@ -898,7 +898,7 @@ class TestCursorFetching:
         result_row_maker: ResultRowFactory,
         statement_response_factory: StatementResponseFactory,
     ):
-        """Prove that a cursor using RawChangelogProcessor can handle non-insert changelog rows,
+        """Prove that a cursor using ChangelogEventReader can handle non-insert changelog rows,
         returning them as ChangeloggedRow containing the op + row tuple."""
 
         # Statement columns needs to match the result rows being returned.
@@ -961,7 +961,7 @@ class TestCursorFetching:
         result_row_maker: ResultRowFactory,
         statement_response_factory: StatementResponseFactory,
     ):
-        """Prove that a cursor using RawChangelogProcessor can handle non-insert changelog rows,
+        """Prove that a cursor using ChangelogEventReader can handle non-insert changelog rows,
         returning them as ChangeloggedRow containing the op + row-as-dict."""
 
         # Statement columns needs to match the result rows being returned.
@@ -1046,21 +1046,21 @@ class TestClose:
         assert mock_connection_cursor.is_closed is True
         assert mock_connection_cursor.rowcount == -1
 
-    def test_close_releases_changelog_processor(self, mock_connection_cursor: Cursor):
-        """Test that closing the cursor releases the changelog processor reference."""
-        # Execute a query to create a changelog processor
+    def test_close_releases_result_reader(self, mock_connection_cursor: Cursor):
+        """Test that closing the cursor releases the result reader reference."""
+        # Execute a query to create a result reader
         mock_connection_cursor.execute("SELECT 1 AS col")
 
-        # Verify that a changelog processor exists
-        assert mock_connection_cursor._changelog_processor is not None
+        # Verify that a result reader exists
+        assert mock_connection_cursor._result_reader is not None
 
         # Close the cursor
         mock_connection_cursor.close()
 
-        # Verify that the changelog processor reference is dropped for garbage collection
-        # (especially ensures that the changelog processor's reference to the container
+        # Verify that the result reader reference is dropped for garbage collection
+        # (especially ensures that the result reader's reference to the container
         #  holding any fetched pages can be garbage collected to free memory).
-        assert mock_connection_cursor._changelog_processor is None
+        assert mock_connection_cursor._result_reader is None
 
 
 @pytest.mark.unit

--- a/tests/unit/test_result_readers_unit.py
+++ b/tests/unit/test_result_readers_unit.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from confluent_sql.changelog import ChangeloggedRow
 from confluent_sql.changelog_compressor import (
     NoUpsertColumnsDictCompressor,
     NoUpsertColumnsTupleCompressor,
@@ -14,6 +13,7 @@ from confluent_sql.changelog_compressor import (
 )
 from confluent_sql.cursor import Cursor
 from confluent_sql.exceptions import InterfaceError, StatementStoppedError
+from confluent_sql.result_readers import ChangeloggedRow
 from confluent_sql.statement import Op, Schema, Statement, Traits
 
 


### PR DESCRIPTION


## Overview

This is a pure refactoring that improves code clarity by renaming the `changelog` module and its classes to better reflect their actual responsibility: reading and buffering results from the server, not interpreting changelog operations.

## Rationale

The original naming was misleading. These interior utility classes assist Cursor through fetching and buffering results but do NOT process/interpret changelog operations. The rename clarifies the layered architecture and separation of concerns:

**Top Layer (streaming extension to dbapi, public API):**

- **`changelog_compressor`:** Higher-level API for processing revokable changelog statement results by accumulating and interpreting changelog operations (INSERT, UPDATE, DELETE) into logical result set snapshots.

**Middle Layer (dbapi public layer):**

- **`cursor`:** Extended DB-API interface that coordinates result reading and provides standard fetch methods (fetchone, fetchmany, fetchall) and iteration.


**Bottom Layer (not exposed to public API in any way, the one being renamed):**

- **`result_readers`:** Low-level utility code that reads and buffers results from Flink on behalf of Cursor instances (handles paging, type conversion, result buffering). No interpretation of changelog operations.



## Scope

**Files Modified:**

- **Source:** 5 files (module rename, imports, instance variables, docstrings)
- **Tests:** 3 files (fixture/comment updates)

**No behavioral changes.** All functionality remains identical.

### Module Rename

- `changelog.py` → `result_readers.py`

### Class Renames

- `ChangelogProcessor` → `ResultReader` (abstract base class)
- `AppendOnlyChangelogProcessor` → `AppendOnlyResultReader`
- `RawChangelogProcessor` → `ChangelogEventReader`

## Verification

✅ **Public API unchanged** (ChangeloggedRow still exported)
✅ **No remaining old terminology** (comprehensive search confirmed)
