### PR TITLE
Fix iterating over streaming statement results

### DIFF
--- a/src/confluent_sql/result_readers.py
+++ b/src/confluent_sql/result_readers.py
@@ -397,9 +397,11 @@ class ResultReader(Generic[ReaderOutput], abc.ABC):
         if len(self._results) > 0:
             return self._consume_from_buffer(limit)
 
-        # Buffer is empty - check if we can fetch more
-        if self._fetch_next_page_called and self._next_page is None:
-            # We've already fetched before and there are no more pages
+        # Buffer is empty.
+
+        # Check if we can fetch more
+        if self._is_exhausted():
+            # We've already fetched all available pages
             return []
 
         # Try to fetch one page of results
@@ -422,6 +424,10 @@ class ResultReader(Generic[ReaderOutput], abc.ABC):
             # Or we know there are more pages to fetch.
             or self._next_page is not None
         )
+
+    def _is_exhausted(self) -> bool:
+        """Whether we've fetched all available pages (no more pages to fetch)."""
+        return self._fetch_next_page_called and not self._next_page
 
     def fetchmany(self, size: int) -> list[ReaderOutput]:
         """
@@ -499,29 +505,43 @@ class ResultReader(Generic[ReaderOutput], abc.ABC):
     def __next__(self) -> ReaderOutput:
         """Implementation of iterator protocol.
 
+        If there are buffered results in the deque, return the next one immediately.
+
         This method implements blocking iteration behavior:
-        - When the buffer is empty, it calls _fetch_next_page() to get more data
+        - When the buffer is empty and we know there may be more data, it calls
+          _fetch_next_page() to (try) to get it.
         - Raises StopIteration only when no more results will ever be available
         - In streaming mode, this means iteration will block/wait for new data
 
         Note: This blocking behavior differs from fetchone/fetchmany in streaming
         mode, which return immediately with None/empty list if no data is buffered.
         """
-        if len(self._results) == 0:
-            # Detect iteration exhaustion: we've fetched before AND there's nowhere
-            # else to fetch from. Using _fetch_next_page_called flag rather than
-            # buffer state because deque's destructive popleft() consumption leaves
-            # an empty deque indistinguishable from "never fetched yet".
-            if self._fetch_next_page_called and not self._next_page:
-                raise StopIteration
-            self._fetch_next_page()
-            if len(self._results) == 0:
+        while True:
+            # If buffer has results, return one immediately
+            if len(self._results) > 0:
+                return self._results.popleft()
+
+            # Buffer is empty. Check if we've exhausted all available pages.
+            # Using _fetch_next_page_called flag rather than buffer state because
+            # deque's destructive popleft() consumption leaves an empty deque
+            # indistinguishable from "never fetched yet".
+            if self._is_exhausted():
                 raise StopIteration
 
-        return self._results.popleft()
+            # Try to fetch the next page. In streaming scenarios, this may return
+            # an empty page if data hasn't arrived yet (and self._results will remain empty).
+            # Keep looping to retry.
+            #
+            # (This is not a completely hard loop because _fetch_next_page() internally
+            # pauses to avoid hammering the server with requests when data currently available.)
+            self._fetch_next_page()
 
     def _fetch_next_page(self) -> None:
-        """Fetch and process the next page of results."""
+        """Try to fetch and process the next page of results.
+
+        Pauses momentarily periodically if configured to avoid hard loops
+        and possible rate limiting when data isn't available yet in streaming scenarios.
+        """
 
         if not self._statement.can_fetch_results(self._execution_mode):
             raise InterfaceError("Statement is not ready for result fetching.")
@@ -529,51 +549,52 @@ class ResultReader(Generic[ReaderOutput], abc.ABC):
         if not self._statement.schema:
             raise InterfaceError("Trying to fetch results for a non-query statement")
 
-        if not self._results or self._next_page is not None:
-            if self._most_recent_results_fetch_time is not None:
-                # Should we pause before fetching the next page?
-                elapsed_secs = time.monotonic() - self._most_recent_results_fetch_time
-                if elapsed_secs < self._connection.statement_results_page_fetch_pause_secs:
-                    # Sleep the difference between when we last fetched results
-                    # and the configured pause time so that we ensure to not
-                    # hit the endpoint for this statement more often than
-                    # the configured pause time.
-                    pause_secs = (
-                        self._connection.statement_results_page_fetch_pause_secs - elapsed_secs
-                    )
-                    time.sleep(pause_secs)
-                    self._metrics.paused_before_fetch(pause_secs)
+        if self._most_recent_results_fetch_time is not None:
+            # Should we pause before fetching the next page?
+            elapsed_secs = time.monotonic() - self._most_recent_results_fetch_time
+            if elapsed_secs < self._connection.statement_results_page_fetch_pause_secs:
+                # Sleep the difference between when we last fetched results
+                # and the configured pause time so that we ensure to not
+                # hit the endpoint for this statement more often than
+                # the configured pause time.
+                pause_secs = self._connection.statement_results_page_fetch_pause_secs - elapsed_secs
+                time.sleep(pause_secs)
+                self._metrics.paused_before_fetch(pause_secs)
 
-            self._metrics.prep_for_fetch()
+        self._metrics.prep_for_fetch()
 
-            # Get raw ChangelogRow results from connection
-            results, next_page = self._connection._get_statement_results(
-                self._statement.name, self._next_page
-            )
+        # Get (possibly empty) list of ChangelogRow results from the server and the next page link,
+        # if any, for the next fetch.
+        results, next_page_link = self._connection._get_statement_results(
+            self._statement.name, self._next_page
+        )
 
-            self._metrics.record_fetch_completion(len(results))
-
-            self._next_page = next_page
-
-            # Process each changelog row just fetched
-            type_converter = self._statement.type_converter
-            # Lazily initialize formatter when we first need it (ensures schema is available)
-            if self._row_formatter is None:
-                self._row_formatter = RowFormatter.create(
-                    self._as_dict, self._statement.schema
-                )
-            for res in results:
-                # Convert row to Python types
-                decoded_row = type_converter.to_python_row(res.row)
-
-                # Format row according to cursor's as_dict setting (tuple or dict)
-                formatted_row = self._row_formatter.format(decoded_row)
-
-                # Retain the row (and perhaps also the operation) in the reader's internal state
-                self._retain(res.op, formatted_row)
-
+        # Do the accounting that we did just fetch results
         self._fetch_next_page_called = True
         self._most_recent_results_fetch_time = time.monotonic()
+        self._metrics.record_fetch_completion(len(results))
+        self._next_page = next_page_link
+
+        if len(results) == 0:
+            return  # No results to process, but we did just fetch and update metrics, so return
+
+        # Process each changelog row just fetched ...
+
+        # Capture the needed parts into local variables for faster access in the per-result-row loop
+        type_converter_to_python_row = self._statement.type_converter.to_python_row
+        if self._row_formatter is None:
+            # Lazily initialize formatter when we first need it (ensures schema is available)
+            self._row_formatter = RowFormatter.create(self._as_dict, self._statement.schema)
+        row_formatter_format = self._row_formatter.format
+        retain = self._retain
+
+        for res in results:
+            # Promote row members from their JSON encoding to Python types
+            decoded_row = type_converter_to_python_row(res.row)
+            # Format row according to cursor's as_dict setting (tuple or dict)
+            formatted_row = row_formatter_format(decoded_row)
+            # Retain the row (and perhaps also the operation) in the reader's internal state
+            retain(res.op, formatted_row)
 
 
 class AppendOnlyResultReader(ResultReader[ResultTupleOrDict]):
@@ -599,9 +620,7 @@ class AppendOnlyResultReader(ResultReader[ResultTupleOrDict]):
         if op is not None and op != Op.INSERT:
             # Only expect INSERT operations for append-only
             logger.error(f"Received non-INSERT op {op} in results for append-only statement.")
-            raise NotSupportedError(
-                f"Non-INSERT op was received by AppendOnlyResultReader: {op}. "
-            )
+            raise NotSupportedError(f"Non-INSERT op was received by AppendOnlyResultReader: {op}. ")
 
         self._results.append(decoded)
 

--- a/tests/integration/test_cursor.py
+++ b/tests/integration/test_cursor.py
@@ -754,3 +754,78 @@ class TestStreamingChangelogCursor:
                 # Cleanup
                 cursor.delete_statement()
                 cursor.close()
+
+    @pytest.mark.slow
+    def test_streaming_append_only_iteration_collects_all_rows(self, connection: Connection):
+        """Integration test verifying that streaming append-only iteration doesn't short-circuit
+        when encountering empty pages.
+
+        This test replicates the example in examples/simple_append_only_streaming_query_example.py
+        and demonstrates the fix for the bug where iteration would raise StopIteration after
+        fetching an empty page, even if more data was available.
+
+        The test:
+        1. Creates a table with sample data
+        2. Executes a streaming append-only SELECT query
+        3. Iterates using 'for row in cursor' syntax
+        4. Verifies all rows are observed via iteration
+        5. Cleans up the table
+
+        This proves that iteration correctly handles streaming mode where servers may return
+        empty pages while data is still arriving.
+        """
+
+        # Create a unique table name for this test
+        table_name = f"test_streaming_iteration_{uuid4().hex[:8]}"
+
+        try:
+            # Step 1: Create table with sample data
+            with connection.closing_cursor() as cursor:
+                cursor.execute(
+                    f"""
+                    CREATE TABLE {table_name} (
+                        id INT,
+                        name STRING
+                    )
+                    """
+                )
+                cursor.execute(
+                    f"""
+                    INSERT INTO {table_name} (id, name) VALUES
+                    (1, 'Alice'),
+                    (2, 'Bob'),
+                    (3, 'Charlie')
+                    """
+                )
+
+            # Step 2: Execute streaming query and iterate
+            with connection.closing_streaming_cursor(as_dict=True) as cursor:
+                cursor.execute(f"SELECT id, name FROM {table_name}")
+
+                # Verify this is an append-only streaming query
+                assert cursor.statement.is_append_only is True, (
+                    "Expected statement to be append-only"
+                )
+                assert cursor.is_streaming is True, "Expected cursor to be in streaming mode"
+
+                # Step 3: Iterate and collect all rows
+                # This is the critical part - in the buggy version, iteration would stop
+                # prematurely after empty pages, collecting 0 rows instead of 3.
+                names_observed: set[str] = set()
+                for row in cursor:
+                    assert isinstance(row, dict), f"Expected dict row, got {type(row)}: {row}"
+                    names_observed.add(row["name"])
+
+                    # Break after observing all names (as in the example)
+                    if names_observed == {"Alice", "Bob", "Charlie"}:
+                        break
+
+            # Step 4: Verify all expected rows were observed
+            assert names_observed == {"Alice", "Bob", "Charlie"}, (
+                f"Expected to observe all three names via iteration, but got: {names_observed}"
+            )
+
+        finally:
+            # Step 5: Clean up the table
+            with connection.closing_cursor() as cursor:
+                cursor.execute(f"DROP TABLE IF EXISTS {table_name}")

--- a/tests/unit/test_changelog_unit.py
+++ b/tests/unit/test_changelog_unit.py
@@ -174,9 +174,7 @@ class TestFetchMethods:
         assert fetch_tracker["count"] == 2, "Should have fetched twice"
         assert result4 == [("page2_row1",), ("page2_row2",)]
 
-    def test_fetchmany_makes_at_most_one_fetch(
-        self, append_only_reader: AppendOnlyResultReader
-    ):
+    def test_fetchmany_makes_at_most_one_fetch(self, append_only_reader: AppendOnlyResultReader):
         """Test that fetchmany makes at most one fetch request per call.
 
         When the buffer is empty and fetchmany is called with a large size,
@@ -264,9 +262,7 @@ class TestFetchMethods:
         AppendOnlyResultReader."""
         statement = statement_factory(is_append_only=True)
         # Create reader in STREAMING_QUERY mode
-        reader = AppendOnlyResultReader(
-            mock_connection, statement, ExecutionMode.STREAMING_QUERY
-        )
+        reader = AppendOnlyResultReader(mock_connection, statement, ExecutionMode.STREAMING_QUERY)
 
         fetch_count = 0
 
@@ -341,9 +337,7 @@ class TestFetchMethods:
         """Test that fetchone() makes at most one fetch per call in streaming mode."""
         statement = statement_factory(is_append_only=True)
         # Create reader in STREAMING_QUERY mode
-        reader = AppendOnlyResultReader(
-            mock_connection, statement, ExecutionMode.STREAMING_QUERY
-        )
+        reader = AppendOnlyResultReader(mock_connection, statement, ExecutionMode.STREAMING_QUERY)
 
         fetch_count = 0
 
@@ -419,13 +413,9 @@ class TestFetchMethods:
         fetched = append_only_reader.fetchone()
         assert fetched is None, f"Expected to fetch None when no more results, got {fetched}"
 
-    def test_fetchall_against_bounded_statement(
-        self, append_only_reader: AppendOnlyResultReader
-    ):
+    def test_fetchall_against_bounded_statement(self, append_only_reader: AppendOnlyResultReader):
         # By default the statement from the fixture should be bounded.
-        assert append_only_reader._statement.is_bounded, (
-            "Statement should be bounded for this test"
-        )
+        assert append_only_reader._statement.is_bounded, "Statement should be bounded for this test"
 
         # Mock some results in the reader
         append_only_reader._results = deque([("row1",), ("row2",), ("row3",)])
@@ -436,9 +426,7 @@ class TestFetchMethods:
             f"Expected to fetch all rows, got {fetched}"
         )
 
-    def test_fetchall_vs_streaming_results(
-        self, append_only_reader: AppendOnlyResultReader
-    ):
+    def test_fetchall_vs_streaming_results(self, append_only_reader: AppendOnlyResultReader):
         # Doctor the reader's statement to have come from a streaming query
         append_only_reader._statement.traits.is_bounded = False  # type: ignore
 
@@ -452,9 +440,7 @@ class TestFetchMethods:
 
 @pytest.mark.unit
 class TestIteration:
-    def test_iteration_over_onhand_results(
-        self, append_only_reader: AppendOnlyResultReader
-    ):
+    def test_iteration_over_onhand_results(self, append_only_reader: AppendOnlyResultReader):
         # Mock some results in the reader
         append_only_reader._results = deque([("row1",), ("row2",), ("row3",)])
 
@@ -467,9 +453,7 @@ class TestIteration:
             f"Expected to collect all rows through iteration, got {collected}"
         )
 
-    def test_iteration_calls_fetch_next_page(
-        self, append_only_reader: AppendOnlyResultReader
-    ):
+    def test_iteration_calls_fetch_next_page(self, append_only_reader: AppendOnlyResultReader):
         # Mock the _fetch_next_page method to track calls
         call_tracker = {"called": False}
 
@@ -494,9 +478,7 @@ class TestIteration:
             f"Expected to collect fetched rows through iteration, got {collected}"
         )
 
-    def test_iteration_stops_when_no_more_results(
-        self, append_only_reader: AppendOnlyResultReader
-    ):
+    def test_iteration_stops_when_no_more_results(self, append_only_reader: AppendOnlyResultReader):
         # Mock the _fetch_next_page method to simulate no results and no next page
         def mock_fetch_next_page():
             append_only_reader._results = deque()
@@ -546,9 +528,7 @@ class TestIteration:
 
 @pytest.mark.unit
 class TestFetchNextPage:
-    def test_raises_if_statement_not_ready(
-        self, append_only_reader: AppendOnlyResultReader
-    ):
+    def test_raises_if_statement_not_ready(self, append_only_reader: AppendOnlyResultReader):
         # Append-only statements in streaming mode are ready when RUNNING.
         # But a statement in PENDING phase is never ready, so test that instead.
         append_only_reader._statement._phase = Phase.PENDING
@@ -706,10 +686,12 @@ class TestChangelogEventReader:
             fetch_count += 1
             if fetch_count == 1:
                 # First fetch returns 2 changelog rows
-                reader._results = deque([
-                    ChangeloggedRow(Op.INSERT, ("row1",)),
-                    ChangeloggedRow(Op.UPDATE_BEFORE, ("row2",)),
-                ])
+                reader._results = deque(
+                    [
+                        ChangeloggedRow(Op.INSERT, ("row1",)),
+                        ChangeloggedRow(Op.UPDATE_BEFORE, ("row2",)),
+                    ]
+                )
                 reader._next_page = "page2"
             elif fetch_count == 2:
                 # Second fetch returns 2 more changelog rows
@@ -750,9 +732,7 @@ class TestFetchMetrics:
         assert metrics.paused_secs == pytest.approx(0.0)
         assert metrics.avg_rows_per_page == pytest.approx(0.0)
 
-    def test_metrics_updated_during_fetch(
-        self, append_only_reader: AppendOnlyResultReader
-    ):
+    def test_metrics_updated_during_fetch(self, append_only_reader: AppendOnlyResultReader):
         """Test that metrics are properly updated when fetching pages."""
 
         # Mock the connection's _get_statement_results to return results
@@ -785,39 +765,55 @@ class TestFetchMetrics:
         assert metrics.avg_rows_per_page == pytest.approx(3.0)
 
     def test_metrics_with_pausing(self, append_only_reader: AppendOnlyResultReader):
-        """Test that pausing metrics are tracked correctly."""
+        """Test that pausing metrics are tracked correctly when fetching multiple pages."""
         # Set up connection pause time
         append_only_reader._connection.statement_results_page_fetch_pause_secs = 2.0
 
-        # Mock get_statement_results to return some rows
+        # Mock get_statement_results to return rows with a next page on first call,
+        # then different rows on second call (to test pause between fetches)
+        call_count = 0
+
         def mock_get_statement_results(
             statement_name: str, next_url: str | None
         ) -> tuple[list[ChangelogRow], str | None]:
-            return [ChangelogRow(Op.INSERT.value, ["value1"])], None
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # First fetch returns a row and indicates more pages
+                return [ChangelogRow(Op.INSERT.value, ["value1"])], "page_2_token"
+            else:
+                # Second fetch returns another row and no more pages
+                return [ChangelogRow(Op.INSERT.value, ["value2"])], None
 
         append_only_reader._connection._get_statement_results = mock_get_statement_results
 
-        # Set up state as if we had fetched before (to trigger pause logic)
-        append_only_reader._results = deque()
-        append_only_reader._most_recent_results_fetch_time = 99.0  # Previous fetch time
-        append_only_reader._fetch_next_page_called = True
-
-        # Mock time to simulate: current time is 99.5, so only 0.5 seconds elapsed
-        # This means we need to pause for 1.5 seconds (2.0 - 0.5)
-        # Need: elapsed check, prep_for_fetch, record_fetch_completion, setting
-        # _most_recent_results_fetch_time
+        # First fetch: prep_for_fetch (100.0), record_fetch_completion (100.05),
+        #             setting _most_recent_results_fetch_time (100.05)
+        # Second fetch: elapsed check (100.55), prep_for_fetch (100.6),
+        #             record_fetch_completion (100.65), setting _most_recent_results_fetch_time
+        #               (100.65)
+        # Elapsed is 100.55 - 100.05 = 0.5 seconds, pause needed = 2.0 - 0.5 = 1.5 seconds
         with (
-            patch("time.monotonic", side_effect=[99.5, 100.0, 100.1, 100.1]),
+            patch(
+                "time.monotonic", side_effect=[100.0, 100.05, 100.05, 100.55, 100.6, 100.65, 100.65]
+            ),
             patch("time.sleep") as mock_sleep,
         ):
+            # First fetch (no pause, first call ever)
+            append_only_reader._fetch_next_page()
+
+            # Clear results to simulate consumption, but keep the next_page token
+            append_only_reader._results = deque()
+
+            # Second fetch (should pause because not enough time has elapsed)
             append_only_reader._fetch_next_page()
             mock_sleep.assert_called_once_with(1.5)
 
         metrics = append_only_reader.metrics
         assert metrics.paused_times == 1
         assert metrics.paused_secs == pytest.approx(1.5)
-        assert metrics.total_page_fetches == 1
-        assert metrics.fetch_request_secs == pytest.approx(0.1)  # 100.1 - 100.0
+        assert metrics.total_page_fetches == 2
+        assert metrics.total_changelog_rows_fetched == 2
 
     def test_metrics_empty_page_fetch(self, append_only_reader: AppendOnlyResultReader):
         """Test that empty page fetches are tracked."""

--- a/tests/unit/test_result_readers_unit.py
+++ b/tests/unit/test_result_readers_unit.py
@@ -30,6 +30,22 @@ def schema_fixture():
     return schema
 
 
+@pytest.fixture
+def mock_connection():
+    """Create a mock connection for testing."""
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_statement_with_schema(schema_fixture):
+    """Create a mock statement with schema."""
+    statement = MagicMock(spec=Statement)
+    statement.name = "test-query"
+    statement.schema = schema_fixture
+    statement.type_converter = MagicMock()
+    return statement
+
+
 @pytest.mark.unit
 class TestRowFormatter:
     """Tests for RowFormatter family (RowFormatter, TupleRowFormatter, DictRowFormatter)."""
@@ -202,3 +218,140 @@ class TestAppendOnlyResultReader:
         # Now formatter should be created and be a TupleRowFormatter
         assert reader._row_formatter is not None
         assert isinstance(reader._row_formatter, TupleRowFormatter)
+
+    def test_iteration_handles_empty_first_page_with_next_page_available(
+        self, mock_connection, mock_statement_with_schema
+    ):
+        """Test that iteration doesn't short-circuit when the first page is empty but more pages
+        exist.
+
+        This test reproduces the bug where iteration would raise StopIteration immediately
+        after fetching an empty page, even though _next_page indicates more pages are available.
+
+        In streaming mode, the server may return an empty initial page while data is still arriving.
+        The iterator should keep trying to fetch data instead of giving up prematurely.
+
+        Scenario:
+        1. First __next__() call fetches page 1: empty results, but _next_page="page_2_token"
+        2. Second __next__() call should fetch page 2: has actual row data
+        3. Iterator should return rows, not raise StopIteration after empty page
+        """
+        # Setup: Mock the server to return empty first page, then results on second page
+        mock_statement_with_schema.can_fetch_results.return_value = True
+        mock_statement_with_schema.type_converter.to_python_row.side_effect = [
+            # Second fetch will return actual rows
+            (1, "alice", 100),
+            (2, "bob", 200),
+        ]
+
+        # Mock the connection's pause configuration (no pause between fetches)
+        mock_connection.statement_results_page_fetch_pause_secs = 0.0
+
+        # First call to _get_statement_results returns empty page with next_page token
+        # Second call returns actual rows with no next page
+        mock_connection._get_statement_results.side_effect = [
+            ([], "page_2_token"),  # Empty first page, but more to come
+            (
+                [
+                    ChangeloggedRow(Op.INSERT, (1, "alice", 100)),
+                    ChangeloggedRow(Op.INSERT, (2, "bob", 200)),
+                ],
+                None,
+            ),  # Rows on second page, no more after
+        ]
+
+        reader = AppendOnlyResultReader(
+            connection=mock_connection,
+            statement=mock_statement_with_schema,
+            execution_mode=ExecutionMode.STREAMING_QUERY,
+            as_dict=False,
+        )
+
+        # Attempt to iterate and collect all rows
+        collected_rows = []
+        try:
+            for row in reader:
+                collected_rows.append(row)
+        except StopIteration:
+            # If we get StopIteration before collecting rows, the bug is present
+            pass
+
+        # EXPECTED: Should have collected both rows (1, "alice", 100) and (2, "bob", 200)
+        # ACTUAL WITH BUG: Iterator raises StopIteration after empty first page, never fetching
+        # page 2
+        assert len(collected_rows) == 2, (
+            f"Expected 2 rows but got {len(collected_rows)}. "
+            "Bug present: __next__() raises StopIteration after empty page, "
+            "even though _next_page indicates more pages are available."
+        )
+        assert collected_rows[0] == (1, "alice", 100)
+        assert collected_rows[1] == (2, "bob", 200)
+
+
+@pytest.mark.unit
+class TestIsExhausted:
+    """Tests for the _is_exhausted() helper method."""
+
+    def test_is_exhausted_when_fetch_called_and_no_next_page(
+        self, mock_connection, mock_statement_with_schema
+    ):
+        """Test that _is_exhausted() returns True when we've fetched and there's no next page."""
+        mock_statement_with_schema.can_fetch_results.return_value = True
+        mock_statement_with_schema.type_converter.to_python_row.return_value = (1, "test", 3.14)
+
+        mock_connection._get_statement_results.return_value = (
+            [ChangeloggedRow(Op.INSERT, (1, "test", 3.14))],
+            None,  # No next page
+        )
+
+        reader = AppendOnlyResultReader(
+            connection=mock_connection,
+            statement=mock_statement_with_schema,
+            execution_mode=ExecutionMode.SNAPSHOT,
+            as_dict=False,
+        )
+
+        # Fetch once, which sets _fetch_next_page_called=True and _next_page=None
+        reader._fetch_next_page()
+
+        # Should be exhausted
+        assert reader._is_exhausted() is True
+
+    def test_is_exhausted_false_when_never_fetched(
+        self, mock_connection, mock_statement_with_schema
+    ):
+        """Test that _is_exhausted() returns False when we've never fetched yet."""
+        reader = AppendOnlyResultReader(
+            connection=mock_connection,
+            statement=mock_statement_with_schema,
+            execution_mode=ExecutionMode.SNAPSHOT,
+            as_dict=False,
+        )
+
+        # Should not be exhausted (we haven't fetched yet)
+        assert reader._is_exhausted() is False
+
+    def test_is_exhausted_false_when_next_page_available(
+        self, mock_connection, mock_statement_with_schema
+    ):
+        """Test that _is_exhausted() returns False when there's a next page available."""
+        mock_statement_with_schema.can_fetch_results.return_value = True
+        mock_statement_with_schema.type_converter.to_python_row.return_value = (1, "test", 3.14)
+
+        mock_connection._get_statement_results.return_value = (
+            [ChangeloggedRow(Op.INSERT, (1, "test", 3.14))],
+            "next_page_token",  # Next page available
+        )
+
+        reader = AppendOnlyResultReader(
+            connection=mock_connection,
+            statement=mock_statement_with_schema,
+            execution_mode=ExecutionMode.SNAPSHOT,
+            as_dict=False,
+        )
+
+        # Fetch once, which sets _fetch_next_page_called=True and _next_page="next_page_token"
+        reader._fetch_next_page()
+
+        # Should not be exhausted (more pages available)
+        assert reader._is_exhausted() is False


### PR DESCRIPTION
This PR fixes a critical bug in streaming statement result iteration where the __next__() method would raise StopIteration prematurely after a single empty page fetch, even when more data was available (indicated by _next_page).

In master, the logic was originally written for snapshot-mode statements when we would never get to try to iterate until the statement had completed execution and all of the results were available:

*  Fetch a page
* If empty → immediately raise StopIteration

The bug: In streaming mode, servers may return empty pages while data is still being generated (indicated by non-null _next_page URL). This caused iteration over the cursor to terminate prematurely. The author's prior testing with streaming statements was using the fetchmany() path and was therefore shielded from encountering this previously. Testing iteration with snapshot statements would work fine, because we'd never get to this point until after when statement execution was completed.

This PR changes __next__() to a polling loop that retries fetching until truly exhausted, enabling correct iteration over both streaming results and snapshot statement results. Additionally, it includes performance optimizations and comprehensive test coverage -- it comments up and captures methods to local variables for the hot path of the per-result loop.

*(stacked on top of branch `closing_streaming_cursor`, both forked out from the big docs branch that prompted this discovery)*