### PR TITLE
Remove unused `api_key` and `api_secret` connect() parameters ...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,17 @@ All notable changes to this dbapi driver will be documented in this file.
 
 ## Unreleased
 
-### Added
-  * New optional keyword parameter `properties: PropertiesDict | None` on `Cursor.execute()` and related methods to allow callers to provide [statement execution properties](https://docs.confluent.io/cloud/current/flink/reference/statements/set.html#table-options). Note: connection or cursor-level properties for default catalog, database, and execution mode cannot be overridden by this parameter.
-
 ### Changed
   * Respelled the `connect()` parameter `dbname` to `database`. The old spelling `dbname` is deprecated and will be removed in after one release cycle.
   * `connect()` is now keyword-only callable.
+  * The `host` parameter for `Connection.__init__()` has been renamed to `endpoint`.
+
+### Added
+  * New optional keyword parameter `properties: PropertiesDict | None` on `Cursor.execute()` and related methods to allow callers to provide [statement execution properties](https://docs.confluent.io/cloud/current/flink/reference/statements/set.html#table-options). Note: connection or cursor-level properties for default catalog, database, and execution mode cannot be overridden by this parameter.
+  * New optional `endpoint` parameter on `connect()` and `Connection.__init__` to allow users to specify a custom Confluent Cloud API base endpoint (e.g., for private networking, staging, etc.). Mutually exclusive with (`cloud_provider`, `cloud_region`) -- either `endpoint` or (`cloud_provider`, `cloud_region`) must be provided. This replaces the `host` parameter in `Connection.__init__()`. (#66)
 
 ### Removed
   * The unused control-plane `api_key` and `api_secret` `connect()` parameters have been removed. The Flink regional API key params `flink_api_key` and `flink_api_secret` remain.
-
 
 ## 0.1.x
 

--- a/src/confluent_sql/connection.py
+++ b/src/confluent_sql/connection.py
@@ -36,9 +36,10 @@ def connect(  # noqa: PLR0913
     environment: str,
     compute_pool_id: str,
     organization_id: str,
-    cloud_provider: str,
-    cloud_region: str,
+    cloud_provider: str | None = None,
+    cloud_region: str | None = None,
     database: str | None = None,
+    endpoint: str | None = None,
     dbname: str | None = None,  # deprecated, use database parameter
     result_page_fetch_pause_millis: int = 100,
     http_user_agent: str | None = None,
@@ -52,10 +53,17 @@ def connect(  # noqa: PLR0913
         environment: Environment ID
         compute_pool_id: Compute pool ID for SQL execution
         organization_id: Organization ID
-        cloud_provider: Cloud provider (e.g., "aws", "gcp", "azure")
-        cloud_region: Cloud region (e.g., "us-east-2", "us-west-2")
+        cloud_provider: Cloud provider (e.g., "aws", "gcp", "azure"). Required if endpoint is not
+            provided; must not be provided if endpoint is specified.
+        cloud_region: Cloud region (e.g., "us-east-2", "us-west-2"). Required if endpoint is not
+            provided; must not be provided if endpoint is specified.
         database: The default Flink database (Kafka cluster) to use when resolving
             table/view/udf names (optional)
+        endpoint: The base URL for Confluent Cloud API (optional). If not provided, the endpoint
+            will be constructed based on the cloud_provider and cloud_region parameters in the
+            format "https://flink.{cloud_region}.{cloud_provider}.confluent.cloud". A trailing
+            slash is optional and will be stripped if provided (e.g., both
+            "https://custom.example.com" and "https://custom.example.com/" are accepted).
         dbname: Deprecated alias for database parameter (optional)
         result_page_fetch_pause_millis: Maximum milliseconds to wait between fetching pages of
             statement results (per statement). Defaults to 100ms. Prevents tight loops of requests
@@ -88,11 +96,17 @@ def connect(  # noqa: PLR0913
     if not organization_id:
         raise InterfaceError("Organization ID is required")
 
-    if not cloud_provider:
-        raise InterfaceError("Cloud provider is required")
+    if endpoint:
+        if cloud_provider or cloud_region:
+            raise InterfaceError(
+                "cloud_provider and cloud_region should not be provided when endpoint is specified"
+            )
+    else:
+        if not cloud_provider:
+            raise InterfaceError("Cloud provider is required when endpoint is not provided")
 
-    if not cloud_region:
-        raise InterfaceError("Cloud region is required")
+        if not cloud_region:
+            raise InterfaceError("Cloud region is required when endpoint is not provided")
 
     if not flink_api_key or not flink_api_secret:
         raise InterfaceError("Flink API key and secret are required")
@@ -117,6 +131,7 @@ def connect(  # noqa: PLR0913
         organization_id,
         cloud_provider,
         cloud_region,
+        endpoint,
         database=database or dbname,  # dbname is deprecated.
         statement_results_page_fetch_pause_millis=result_page_fetch_pause_millis,
         http_user_agent=http_user_agent,
@@ -138,7 +153,6 @@ class Connection:
     environment: str
     organization_id: str
     compute_pool_id: str
-    host: str | None
     statement_results_page_fetch_pause_secs: float
     """Maximum seconds to wait between fetching pages of statement
         results (per statement). Prevents tight loops of requests to the
@@ -173,9 +187,9 @@ class Connection:
         environment: str,
         compute_pool_id: str,
         organization_id: str,
-        cloud_provider: str,
-        cloud_region: str,
-        host: str | None = None,
+        cloud_provider: str | None,
+        cloud_region: str | None,
+        endpoint: str | None,
         database: str | None = None,
         statement_results_page_fetch_pause_millis: int = 100,
         http_user_agent: str | None = None,
@@ -189,14 +203,18 @@ class Connection:
             environment: Environment ID
             compute_pool_id: Compute pool ID for SQL execution
             organization_id: Organization ID
-            cloud_provider: Cloud provider
-            cloud_region: Cloud region (e.g., "us-east-2", "us-west-2")
+            cloud_provider: Cloud provider (required if endpoint is not provided)
+            cloud_region: Cloud region (e.g., "us-east-2", "us-west-2"). Required if endpoint is
+                not provided.
+            endpoint: The base URL for Confluent Cloud API (optional). If not provided, the
+                endpoint will be constructed based on the cloud_provider and cloud_region
+                parameters in the format "https://flink.{cloud_region}.{cloud_provider}.confluent.cloud".
+                A trailing slash is optional and will be stripped if provided.
+            database: The name of the database to use (optional)
             result_page_fetch_pause_millis: Milliseconds to possibly wait between fetching pages of
                 statement results. Defaults to 100ms. If most recent fetch of results for a
                 statement was more than this long ago, then no delay will happen when fetching
                 the next page of results for the statement.
-            host: The base URL for Confluent Cloud API (optional)
-            database: The name of the database to use (optional)
             http_user_agent: User-Agent header for HTTP requests. String, 1-100 chars.
                            Defaults to the value of DEFAULT_USER_AGENT, which includes the
                            driver name/version, documentation URL, and support email.
@@ -204,7 +222,6 @@ class Connection:
         self.environment = environment
         self.compute_pool_id = compute_pool_id
         self.organization_id = organization_id
-        self.host = host
 
         if statement_results_page_fetch_pause_millis < 0:
             raise InterfaceError("result_page_fetch_pause_millis must be non-negative")
@@ -224,10 +241,20 @@ class Connection:
             http_user_agent if http_user_agent is not None else self.DEFAULT_USER_AGENT
         )
 
+        if not endpoint and not (cloud_provider and cloud_region):
+            raise InterfaceError(
+                "cloud_provider and cloud_region are required when endpoint is not provided"
+            )
+
         # Create httpx client for making API calls
-        if self.host is None:
-            self.host = f"https://flink.{cloud_region}.{cloud_provider}.confluent.cloud"
-        base_url = f"{self.host}/sql/v1/organizations/{organization_id}/environments/{environment}"
+        if not endpoint:
+            # Construct the endpoint URL based on cloud provider and region.
+            endpoint = f"https://flink.{cloud_region}.{cloud_provider}.confluent.cloud"
+        else:
+            # Strip trailing slash if user provided one, to ensure clean URL construction
+            endpoint = endpoint.rstrip("/")
+
+        base_url = f"{endpoint}/sql/v1/organizations/{organization_id}/environments/{environment}"
 
         # Create httpx client for making API calls
         basic_auth = httpx.BasicAuth(username=flink_api_key, password=flink_api_secret)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,6 +59,7 @@ def connection_factory() -> Generator[ConnectionFactory, None, None]:
         database: str | None = None,
         result_page_fetch_pause_millis: int = 100,
         http_user_agent: str | None = None,
+        endpoint: str | None = None,
     ) -> Connection:
         if flink_api_key is None:
             flink_api_key = os.getenv("CONFLUENT_FLINK_API_KEY", "")
@@ -70,10 +71,13 @@ def connection_factory() -> Generator[ConnectionFactory, None, None]:
             organization_id = os.getenv("CONFLUENT_ORG_ID", "")
         if compute_pool_id is None:
             compute_pool_id = os.getenv("CONFLUENT_COMPUTE_POOL_ID", "")
-        if cloud_provider is None:
-            cloud_provider = os.getenv("CONFLUENT_CLOUD_PROVIDER", "")
-        if cloud_region is None:
-            cloud_region = os.getenv("CONFLUENT_CLOUD_REGION", "")
+        if endpoint is None:
+            # Only fill in cloud_provider and cloud_region from env vars if endpoint is not
+            # provided, otherwise connect will raise an error.
+            if cloud_provider is None:
+                cloud_provider = os.getenv("CONFLUENT_CLOUD_PROVIDER", "")
+            if cloud_region is None:
+                cloud_region = os.getenv("CONFLUENT_CLOUD_REGION", "")
         if database is None:
             database = os.getenv("CONFLUENT_TEST_DBNAME", "")
 
@@ -88,6 +92,7 @@ def connection_factory() -> Generator[ConnectionFactory, None, None]:
             database=database,
             result_page_fetch_pause_millis=result_page_fetch_pause_millis,
             http_user_agent=http_user_agent,
+            endpoint=endpoint,
         )
 
         connections.append(connection)

--- a/tests/unit/test_connection_unit.py
+++ b/tests/unit/test_connection_unit.py
@@ -248,6 +248,39 @@ class TestDeprecatedDbnameParameter:
 
 
 @pytest.mark.unit
+class TestConnectionInit:
+    """Tests for Connection.__init__ method."""
+
+    @pytest.mark.parametrize(
+        "cloud_provider,cloud_region,endpoint",
+        [
+            (None, None, None),
+            ("aws", None, None),
+            (None, "us-east-1", None),
+            ("", "", None),
+            ("aws", "", None),
+            ("", "us-east-1", None),
+        ],
+    )
+    def test_requires_endpoint_or_cloud_info(self, cloud_provider, cloud_region, endpoint):
+        """Test that creating a connection without proper endpoint or cloud info raises an error."""
+        with pytest.raises(
+            InterfaceError,
+            match="cloud_provider and cloud_region are required when endpoint is not provided",
+        ):
+            Connection(
+                environment="foo_id",
+                compute_pool_id="1234",
+                organization_id="4567",
+                flink_api_key="valid-key",
+                flink_api_secret="valid-secret",
+                cloud_provider=cloud_provider,
+                cloud_region=cloud_region,
+                endpoint=endpoint,
+            )
+
+
+@pytest.mark.unit
 class TestConnectChecks:
     """Tests for connection checks when creating a connection."""
 
@@ -267,8 +300,10 @@ class TestConnectChecks:
             connection_factory(environment="foo_id", compute_pool_id="1234", organization_id="")
 
     def test_requires_cloud_provider(self, connection_factory: ConnectionFactory):
-        """Test that creating a connection without a cloud provider raises an error."""
-        with pytest.raises(InterfaceError, match="Cloud provider is required"):
+        """Test that cloud provider is required when endpoint is not provided."""
+        with pytest.raises(
+            InterfaceError, match="Cloud provider is required when endpoint is not provided"
+        ):
             connection_factory(
                 environment="foo_id",
                 compute_pool_id="1234",
@@ -277,8 +312,10 @@ class TestConnectChecks:
             )
 
     def test_requires_cloud_region(self, connection_factory: ConnectionFactory):
-        """Test that creating a connection without a cloud region raises an error."""
-        with pytest.raises(InterfaceError, match="Cloud region is required"):
+        """Test that cloud region is required when host is not provided."""
+        with pytest.raises(
+            InterfaceError, match="Cloud region is required when endpoint is not provided"
+        ):
             connection_factory(
                 environment="foo_id",
                 compute_pool_id="1234",
@@ -286,6 +323,21 @@ class TestConnectChecks:
                 cloud_provider="aws",
                 cloud_region="",
             )
+
+    def test_builds_endpoint_from_cloud_info(self, connection_factory: ConnectionFactory):
+        """Test that when endpoint is not provided, it is built correctly from cloud info."""
+        conn = connection_factory(
+            environment="env-123",
+            organization_id="org-456",
+            compute_pool_id="cp-789",
+            cloud_provider="aws",
+            cloud_region="us-east-1",
+            flink_api_key="test-key",
+            flink_api_secret="test-secret",
+        )
+
+        expected_base_url = "https://flink.us-east-1.aws.confluent.cloud/sql/v1/organizations/org-456/environments/env-123/"
+        assert str(conn._client.base_url) == expected_base_url
 
     def test_requires_flink_api_key(self, connection_factory: ConnectionFactory):
         """Test that creating a connection without a Flink API key raises an error."""
@@ -310,6 +362,105 @@ class TestConnectChecks:
                 cloud_region="us-east-1",
                 flink_api_key="valid-key",
                 flink_api_secret="",
+            )
+
+    def test_endpoint_parameter_uses_custom_endpoint(self, connection_factory: ConnectionFactory):
+        """Test that providing endpoint parameter uses the custom endpoint."""
+        conn = connection_factory(
+            environment="env-123",
+            organization_id="org-456",
+            compute_pool_id="cp-789",
+            flink_api_key="test-key",
+            flink_api_secret="test-secret",
+            endpoint="https://custom.example.com",
+        )
+
+        # Verify base_url constructed with custom host (httpx adds trailing slash)
+        expected_base_url = (
+            "https://custom.example.com/sql/v1/organizations/org-456/environments/env-123/"
+        )
+        assert str(conn._client.base_url) == expected_base_url
+
+    def test_endpoint_parameter_with_trailing_slash(self, connection_factory: ConnectionFactory):
+        """Test that endpoint parameter with trailing slash is stripped correctly."""
+        conn = connection_factory(
+            environment="env-123",
+            organization_id="org-456",
+            compute_pool_id="cp-789",
+            flink_api_key="test-key",
+            flink_api_secret="test-secret",
+            endpoint="https://custom.example.com/",
+        )
+
+        # Verify trailing slash was stripped and URL is clean (no double slashes)
+        base_url = str(conn._client.base_url)
+        assert "custom.example.com" in base_url
+        # Verify no double slashes before /sql (trailing slash should be stripped)
+        assert "//sql" not in base_url
+        assert (
+            base_url
+            == "https://custom.example.com/sql/v1/organizations/org-456/environments/env-123/"
+        )
+
+    def test_endpoint_parameter_without_trailing_slash(self, connection_factory: ConnectionFactory):
+        """Test that endpoint parameter without trailing slash works correctly."""
+        conn = connection_factory(
+            environment="env-123",
+            organization_id="org-456",
+            compute_pool_id="cp-789",
+            flink_api_key="test-key",
+            flink_api_secret="test-secret",
+            endpoint="https://custom.example.com",
+        )
+
+        # Verify URL is clean (same result as with trailing slash)
+        base_url = str(conn._client.base_url)
+        assert "custom.example.com" in base_url
+        # Verify no double slashes
+        assert "//sql" not in base_url
+        assert (
+            base_url
+            == "https://custom.example.com/sql/v1/organizations/org-456/environments/env-123/"
+        )
+
+    def test_endpoint_raises_error_when_cloud_provider_also_provided(
+        self, connection_factory: ConnectionFactory
+    ):
+        """Test that providing endpoint with cloud_provider raises an error."""
+        with pytest.raises(
+            InterfaceError,
+            match=(
+                "cloud_provider and cloud_region should not be provided when endpoint is specified"
+            ),
+        ):
+            connection_factory(
+                environment="env-123",
+                organization_id="org-456",
+                compute_pool_id="cp-789",
+                flink_api_key="test-key",
+                flink_api_secret="test-secret",
+                endpoint="https://custom.example.com",
+                cloud_provider="aws",
+            )
+
+    def test_endpoint_raises_error_when_cloud_region_also_provided(
+        self, connection_factory: ConnectionFactory
+    ):
+        """Test that providing endpoint with cloud_region raises an error."""
+        with pytest.raises(
+            InterfaceError,
+            match=(
+                "cloud_provider and cloud_region should not be provided when endpoint is specified"
+            ),
+        ):
+            connection_factory(
+                environment="env-123",
+                organization_id="org-456",
+                compute_pool_id="cp-789",
+                flink_api_key="test-key",
+                flink_api_secret="test-secret",
+                endpoint="https://custom.example.com",
+                cloud_region="us-east-1",
             )
 
 
@@ -825,9 +976,7 @@ class TestClosingCursor:
     def test_closing_cursor_respects_mode_parameter(self, invalid_credential_connection):
         """Test that closing_cursor respects the mode parameter."""
         # Test with SNAPSHOT mode (default)
-        with invalid_credential_connection.closing_cursor(
-            mode=ExecutionMode.SNAPSHOT
-        ) as cursor:
+        with invalid_credential_connection.closing_cursor(mode=ExecutionMode.SNAPSHOT) as cursor:
             assert cursor is not None
             assert cursor.execution_mode == ExecutionMode.SNAPSHOT
 
@@ -898,12 +1047,13 @@ class TestClosingStreamingCursor:
         assert cursor is not None
         assert cursor.is_closed is True
 
-    def test_closing_streaming_cursor_closes_even_on_exception(
-        self, invalid_credential_connection
-    ):
+    def test_closing_streaming_cursor_closes_even_on_exception(self, invalid_credential_connection):
         """Test that cursor is closed even if an exception is raised in the context."""
         cursor = None
-        with pytest.raises(ValueError), invalid_credential_connection.closing_streaming_cursor() as c:  # noqa: SIM117,E501
+        with (
+            pytest.raises(ValueError),
+            invalid_credential_connection.closing_streaming_cursor() as c,
+        ):  # noqa: SIM117,E501
             cursor = c
             assert cursor.is_closed is False
             raise ValueError("Test exception")
@@ -920,10 +1070,12 @@ class TestClosingStreamingCursor:
         Verifies equivalence to closing_cursor(mode=ExecutionMode.STREAMING_QUERY).
         """
         # Create two cursors - one with closing_streaming_cursor, one with closing_cursor
-        with invalid_credential_connection.closing_streaming_cursor(as_dict=True) as cursor1, \
-             invalid_credential_connection.closing_cursor(
+        with (
+            invalid_credential_connection.closing_streaming_cursor(as_dict=True) as cursor1,
+            invalid_credential_connection.closing_cursor(
                 as_dict=True, mode=ExecutionMode.STREAMING_QUERY
-            ) as cursor2:
+            ) as cursor2,
+        ):
             # Both should have the same execution mode
             assert cursor1.execution_mode == cursor2.execution_mode
             assert cursor1.is_streaming == cursor2.is_streaming


### PR DESCRIPTION
* Remove unused `api_key` and `api_secret` `connect()` parameters (and down through class Connection)
* Make all remaining `connect()` parameters keyword-only.