### PR TITLE
New `endpoint` connect() param to support staging or private networking endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,17 @@ All notable changes to this dbapi driver will be documented in this file.
 
 ## Unreleased
 
-### Added
-  * New optional keyword parameter `properties: PropertiesDict | None` on `Cursor.execute()` and related methods to allow callers to provide [statement execution properties](https://docs.confluent.io/cloud/current/flink/reference/statements/set.html#table-options). Note: connection or cursor-level properties for default catalog, database, and execution mode cannot be overridden by this parameter.
-  * New optional `endpoint` parameter on `connect()` to allow users to specify a custom Confluent Cloud API base endpoint (e.g., for private networking, staging, etc.). Mutually exclusive with (`cloud_provider`, `cloud_region`) -- either `endpoint` or (`cloud_provider`, `cloud_region`) must be provided. (#66)
-
 ### Changed
   * Respelled the `connect()` parameter `dbname` to `database`. The old spelling `dbname` is deprecated and will be removed in after one release cycle.
   * `connect()` is now keyword-only callable.
+  * The `host` parameter for `Connection.__init__()` has been renamed to `endpoint`.
+
+### Added
+  * New optional keyword parameter `properties: PropertiesDict | None` on `Cursor.execute()` and related methods to allow callers to provide [statement execution properties](https://docs.confluent.io/cloud/current/flink/reference/statements/set.html#table-options). Note: connection or cursor-level properties for default catalog, database, and execution mode cannot be overridden by this parameter.
+  * New optional `endpoint` parameter on `connect()` and `Connection.__init__` to allow users to specify a custom Confluent Cloud API base endpoint (e.g., for private networking, staging, etc.). Mutually exclusive with (`cloud_provider`, `cloud_region`) -- either `endpoint` or (`cloud_provider`, `cloud_region`) must be provided. This replaces the `host` parameter in `Connection.__init__()`. (#66)
 
 ### Removed
   * The unused control-plane `api_key` and `api_secret` `connect()` parameters have been removed. The Flink regional API key params `flink_api_key` and `flink_api_secret` remain.
-
 
 ## 0.1.x
 

--- a/src/confluent_sql/connection.py
+++ b/src/confluent_sql/connection.py
@@ -241,6 +241,11 @@ class Connection:
             http_user_agent if http_user_agent is not None else self.DEFAULT_USER_AGENT
         )
 
+        if not endpoint and not (cloud_provider and cloud_region):
+            raise InterfaceError(
+                "cloud_provider and cloud_region are required when endpoint is not provided"
+            )
+
         # Create httpx client for making API calls
         if not endpoint:
             # Construct the endpoint URL based on cloud provider and region.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,10 +71,13 @@ def connection_factory() -> Generator[ConnectionFactory, None, None]:
             organization_id = os.getenv("CONFLUENT_ORG_ID", "")
         if compute_pool_id is None:
             compute_pool_id = os.getenv("CONFLUENT_COMPUTE_POOL_ID", "")
-        if cloud_provider is None:
-            cloud_provider = os.getenv("CONFLUENT_CLOUD_PROVIDER", "")
-        if cloud_region is None:
-            cloud_region = os.getenv("CONFLUENT_CLOUD_REGION", "")
+        if endpoint is None:
+            # Only fill in cloud_provider and cloud_region from env vars if endpoint is not
+            # provided, otherwise connect will raise an error.
+            if cloud_provider is None:
+                cloud_provider = os.getenv("CONFLUENT_CLOUD_PROVIDER", "")
+            if cloud_region is None:
+                cloud_region = os.getenv("CONFLUENT_CLOUD_REGION", "")
         if database is None:
             database = os.getenv("CONFLUENT_TEST_DBNAME", "")
 

--- a/tests/unit/test_connection_unit.py
+++ b/tests/unit/test_connection_unit.py
@@ -248,6 +248,39 @@ class TestDeprecatedDbnameParameter:
 
 
 @pytest.mark.unit
+class TestConnectionInit:
+    """Tests for Connection.__init__ method."""
+
+    @pytest.mark.parametrize(
+        "cloud_provider,cloud_region,endpoint",
+        [
+            (None, None, None),
+            ("aws", None, None),
+            (None, "us-east-1", None),
+            ("", "", None),
+            ("aws", "", None),
+            ("", "us-east-1", None),
+        ],
+    )
+    def test_requires_endpoint_or_cloud_info(self, cloud_provider, cloud_region, endpoint):
+        """Test that creating a connection without proper endpoint or cloud info raises an error."""
+        with pytest.raises(
+            InterfaceError,
+            match="cloud_provider and cloud_region are required when endpoint is not provided",
+        ):
+            Connection(
+                environment="foo_id",
+                compute_pool_id="1234",
+                organization_id="4567",
+                flink_api_key="valid-key",
+                flink_api_secret="valid-secret",
+                cloud_provider=cloud_provider,
+                cloud_region=cloud_region,
+                endpoint=endpoint,
+            )
+
+
+@pytest.mark.unit
 class TestConnectChecks:
     """Tests for connection checks when creating a connection."""
 
@@ -267,7 +300,7 @@ class TestConnectChecks:
             connection_factory(environment="foo_id", compute_pool_id="1234", organization_id="")
 
     def test_requires_cloud_provider(self, connection_factory: ConnectionFactory):
-        """Test that cloud provider is required when host is not provided."""
+        """Test that cloud provider is required when endpoint is not provided."""
         with pytest.raises(
             InterfaceError, match="Cloud provider is required when endpoint is not provided"
         ):
@@ -290,6 +323,21 @@ class TestConnectChecks:
                 cloud_provider="aws",
                 cloud_region="",
             )
+
+    def test_builds_endpoint_from_cloud_info(self, connection_factory: ConnectionFactory):
+        """Test that when endpoint is not provided, it is built correctly from cloud info."""
+        conn = connection_factory(
+            environment="env-123",
+            organization_id="org-456",
+            compute_pool_id="cp-789",
+            cloud_provider="aws",
+            cloud_region="us-east-1",
+            flink_api_key="test-key",
+            flink_api_secret="test-secret",
+        )
+
+        expected_base_url = "https://flink.us-east-1.aws.confluent.cloud/sql/v1/organizations/org-456/environments/env-123/"
+        assert str(conn._client.base_url) == expected_base_url
 
     def test_requires_flink_api_key(self, connection_factory: ConnectionFactory):
         """Test that creating a connection without a Flink API key raises an error."""
@@ -317,7 +365,7 @@ class TestConnectChecks:
             )
 
     def test_endpoint_parameter_uses_custom_endpoint(self, connection_factory: ConnectionFactory):
-        """Test that providing host parameter uses the custom endpoint."""
+        """Test that providing endpoint parameter uses the custom endpoint."""
         conn = connection_factory(
             environment="env-123",
             organization_id="org-456",
@@ -331,39 +379,6 @@ class TestConnectChecks:
         expected_base_url = (
             "https://custom.example.com/sql/v1/organizations/org-456/environments/env-123/"
         )
-        assert str(conn._client.base_url) == expected_base_url
-
-    def test_endpoint_parameter_makes_cloud_params_optional(
-        self, connection_factory: ConnectionFactory
-    ):
-        """Test that cloud_provider and cloud_region are optional when host is provided."""
-        # Should NOT raise error - cloud params are optional with host
-        conn = connection_factory(
-            environment="env-123",
-            organization_id="org-456",
-            compute_pool_id="cp-789",
-            flink_api_key="test-key",
-            flink_api_secret="test-secret",
-            endpoint="https://custom.example.com",
-        )
-
-        # Verify connection was created successfully
-        assert not conn.is_closed
-        assert str(conn._client.base_url).startswith("https://custom.example.com")
-
-    def test_default_endpoint_construction(self, connection_factory: ConnectionFactory):
-        """Test that host is constructed from cloud_provider and cloud_region when not provided."""
-        conn = connection_factory(
-            environment="env-123",
-            organization_id="org-456",
-            compute_pool_id="cp-789",
-            flink_api_key="test-key",
-            flink_api_secret="test-secret",
-            cloud_provider="aws",
-            cloud_region="us-west-2",
-        )
-
-        expected_base_url = "https://flink.us-west-2.aws.confluent.cloud/sql/v1/organizations/org-456/environments/env-123/"
         assert str(conn._client.base_url) == expected_base_url
 
     def test_endpoint_parameter_with_trailing_slash(self, connection_factory: ConnectionFactory):
@@ -382,7 +397,10 @@ class TestConnectChecks:
         assert "custom.example.com" in base_url
         # Verify no double slashes before /sql (trailing slash should be stripped)
         assert "//sql" not in base_url
-        assert base_url == "https://custom.example.com/sql/v1/organizations/org-456/environments/env-123/"
+        assert (
+            base_url
+            == "https://custom.example.com/sql/v1/organizations/org-456/environments/env-123/"
+        )
 
     def test_endpoint_parameter_without_trailing_slash(self, connection_factory: ConnectionFactory):
         """Test that endpoint parameter without trailing slash works correctly."""
@@ -400,7 +418,10 @@ class TestConnectChecks:
         assert "custom.example.com" in base_url
         # Verify no double slashes
         assert "//sql" not in base_url
-        assert base_url == "https://custom.example.com/sql/v1/organizations/org-456/environments/env-123/"
+        assert (
+            base_url
+            == "https://custom.example.com/sql/v1/organizations/org-456/environments/env-123/"
+        )
 
     def test_endpoint_raises_error_when_cloud_provider_also_provided(
         self, connection_factory: ConnectionFactory
@@ -409,8 +430,7 @@ class TestConnectChecks:
         with pytest.raises(
             InterfaceError,
             match=(
-                "cloud_provider and cloud_region should not be provided when endpoint "
-                "is specified"
+                "cloud_provider and cloud_region should not be provided when endpoint is specified"
             ),
         ):
             connection_factory(
@@ -430,8 +450,7 @@ class TestConnectChecks:
         with pytest.raises(
             InterfaceError,
             match=(
-                "cloud_provider and cloud_region should not be provided when endpoint "
-                "is specified"
+                "cloud_provider and cloud_region should not be provided when endpoint is specified"
             ),
         ):
             connection_factory(


### PR DESCRIPTION
New optional `endpoint` parameter on `connect()` to allow users to specify a custom Confluent Cloud API base endpoint (e.g., for private networking, staging, etc.). Mutually exclusive with (`cloud_provider`, `cloud_region`) -- either `endpoint` or (`cloud_provider`, `cloud_region`) must be provided.

Closes #66, replaces the implementation done in https://github.com/confluentinc/confluent-sql/pull/67 .

This is a PR into parent branch also modifying `connect()` parameters. If https://github.com/confluentinc/confluent-sql/pull/74 is reviewed and merged first, then I can rebase against `main` easily enough.