### PR TITLE
Fix/92 rename environment connect param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,14 @@ All notable changes to this dbapi driver will be documented in this file.
 ## Unreleased
 
 ### Changed - Breaking
-  * **BREAKING**: Renamed `environment` parameter to `environment_id` in `connect()` and `Connection.__init__()` to clarify that an environment ID (not name) is required. The internal attribute `Connection.environment` has also been renamed to `Connection.environment_id`. Update all calls from `connect(environment="env-123")` to `connect(environment_id="env-123")`. (#92)
-
-### Changed
-  * Respelled and re-typed the `statement_label: str | None` parameter in `Cursor.execute()` and peers to be `statement_labels: list[str] | None` to allow multiple labels to be applied to a statement, including `HIDDEN_LABEL`.
+  * `connect()` / `Connection.__init__()`: Renamed `environment` parameter to `environment_id` to clarify that an environment ID (_not_ name) is expected. The internal attribute `Connection.environment` has also been renamed to `Connection.environment_id`. Update all calls from `connect(environment="env-123")` to `connect(environment_id="env-123")`. (#92)
+  * `Cursor.execute()` and peers: Respelled and re-typed the `statement_label: str | None` parameter to be `statement_labels: list[str] | None` to allow multiple labels to be applied to a statement, including `HIDDEN_LABEL`.
 
 ### Added
   * New `Connection.get_statement(statement)` method to retrieve statement metadata by name or refresh a Statement object with the latest server state. Accepts either a statement name (string) or a Statement object. Returns a Statement object with current phase, schema, and execution traits. (#86)
   * New `StatementNotFoundError` exception, a subclass of `OperationalError`, raised by `Connection.get_statement(statement)` when attempting to retrieve a statement that does not exist. Provides programmatic access to the statement name via the `statement_name` attribute.
   * New constant `confluent_sql.HIDDEN_LABEL` used for driving `Cursor.execute()` to indicate that the statement should be hidden in default listings in Confluent Cloud UIs. This feature is intended to be used for minor queries, such as when investigating `INFORMATION_SCHEMA`.
+  * Added documentation regarding use of `connect(endpoint=)` parameter to make use of private networking endpoints (README.md, docstrings).
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this dbapi driver will be documented in this file.
 
 ## Unreleased
 
+### Changed - Breaking
+  * **BREAKING**: Renamed `environment` parameter to `environment_id` in `connect()` and `Connection.__init__()` to clarify that an environment ID (not name) is required. The internal attribute `Connection.environment` has also been renamed to `Connection.environment_id`. Update all calls from `connect(environment="env-123")` to `connect(environment_id="env-123")`. (#92)
+
 ### Changed
   * Respelled and re-typed the `statement_label: str | None` parameter in `Cursor.execute()` and peers to be `statement_labels: list[str] | None` to allow multiple labels to be applied to a statement, including `HIDDEN_LABEL`.
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ import confluent_sql
 # Connect to Confluent Cloud Flink SQL
 connection = confluent_sql.connect(
     organization_id="your-org-uuid",
-    environment="env-123456",
+    environment_id="env-123456",
     cloud_provider="aws",
     cloud_region="us-east-2",
     flink_api_key="your-flink-api-key",

--- a/examples/errors.py
+++ b/examples/errors.py
@@ -15,7 +15,7 @@ if __name__ == "__main__":
     conn = confluent_sql.connect(
         flink_api_key=os.getenv("CONFLUENT_FLINK_API_KEY", ""),
         flink_api_secret=os.getenv("CONFLUENT_FLINK_API_SECRET", ""),
-        environment=os.getenv("CONFLUENT_ENV_ID", ""),
+        environment_id=os.getenv("CONFLUENT_ENV_ID", ""),
         organization_id=os.getenv("CONFLUENT_ORG_ID", ""),
         compute_pool_id=os.getenv("CONFLUENT_COMPUTE_POOL_ID", ""),
         cloud_provider=os.getenv("CONFLUENT_CLOUD_PROVIDER", "aws"),

--- a/examples/simple_append_only_streaming_query_example.py
+++ b/examples/simple_append_only_streaming_query_example.py
@@ -8,7 +8,7 @@ import confluent_sql
 conn = confluent_sql.connect(
     flink_api_key=os.getenv("CONFLUENT_FLINK_API_KEY", ""),
     flink_api_secret=os.getenv("CONFLUENT_FLINK_API_SECRET", ""),
-    environment=os.getenv("CONFLUENT_ENV_ID", ""),
+    environment_id=os.getenv("CONFLUENT_ENV_ID", ""),
     organization_id=os.getenv("CONFLUENT_ORG_ID", ""),
     compute_pool_id=os.getenv("CONFLUENT_COMPUTE_POOL_ID", ""),
     cloud_provider=os.getenv("CONFLUENT_CLOUD_PROVIDER", ""),

--- a/examples/snapshot_mode_tuple_cursor_simple_example.py
+++ b/examples/snapshot_mode_tuple_cursor_simple_example.py
@@ -7,7 +7,7 @@ import confluent_sql
 conn = confluent_sql.connect(
     flink_api_key=os.getenv("CONFLUENT_FLINK_API_KEY", ""),
     flink_api_secret=os.getenv("CONFLUENT_FLINK_API_SECRET", ""),
-    environment=os.getenv("CONFLUENT_ENV_ID", ""),
+    environment_id=os.getenv("CONFLUENT_ENV_ID", ""),
     organization_id=os.getenv("CONFLUENT_ORG_ID", ""),
     compute_pool_id=os.getenv("CONFLUENT_COMPUTE_POOL_ID", ""),
     cloud_provider=os.getenv("CONFLUENT_CLOUD_PROVIDER", ""),

--- a/src/confluent_sql/connection.py
+++ b/src/confluent_sql/connection.py
@@ -38,7 +38,7 @@ def connect(  # noqa: PLR0913
     *,
     flink_api_key: str,
     flink_api_secret: str,
-    environment: str,
+    environment_id: str,
     compute_pool_id: str,
     organization_id: str,
     cloud_provider: str | None = None,
@@ -55,7 +55,7 @@ def connect(  # noqa: PLR0913
     Args:
         flink_api_key: Flink region API key
         flink_api_secret: Flink region API secret
-        environment: Environment ID
+        environment_id: Environment ID
         compute_pool_id: Compute pool ID for SQL execution
         organization_id: Organization ID
         cloud_provider: Cloud provider (e.g., "aws", "gcp", "azure"). Required if endpoint is not
@@ -92,7 +92,7 @@ def connect(  # noqa: PLR0913
         OperationalError: If connection cannot be established
     """
 
-    if not environment:
+    if not environment_id:
         raise InterfaceError("Environment ID is required")
 
     if not compute_pool_id:
@@ -131,7 +131,7 @@ def connect(  # noqa: PLR0913
     return Connection(
         flink_api_key,
         flink_api_secret,
-        environment,
+        environment_id,
         compute_pool_id,
         organization_id,
         cloud_provider,
@@ -155,7 +155,7 @@ class Connection:
         f"Confluent-SQL-Dbapi/v{VERSION} (https://confluent.io; support@confluent.io)"
     )
 
-    environment: str
+    environment_id: str
     organization_id: str
     compute_pool_id: str
     statement_results_page_fetch_pause_secs: float
@@ -189,7 +189,7 @@ class Connection:
         self,
         flink_api_key: str,
         flink_api_secret: str,
-        environment: str,
+        environment_id: str,
         compute_pool_id: str,
         organization_id: str,
         cloud_provider: str | None,
@@ -205,7 +205,7 @@ class Connection:
         Args:
             flink_api_key: Flink region API key
             flink_api_secret: Flink region API secret
-            environment: Environment ID
+            environment_id: Environment ID
             compute_pool_id: Compute pool ID for SQL execution
             organization_id: Organization ID
             cloud_provider: Cloud provider (required if endpoint is not provided)
@@ -224,7 +224,7 @@ class Connection:
                            Defaults to the value of DEFAULT_USER_AGENT, which includes the
                            driver name/version, documentation URL, and support email.
         """
-        self.environment = environment
+        self.environment_id = environment_id
         self.compute_pool_id = compute_pool_id
         self.organization_id = organization_id
 
@@ -259,7 +259,7 @@ class Connection:
             # Strip trailing slash if user provided one, to ensure clean URL construction
             endpoint = endpoint.rstrip("/")
 
-        base_url = f"{endpoint}/sql/v1/organizations/{organization_id}/environments/{environment}"
+        base_url = f"{endpoint}/sql/v1/organizations/{organization_id}/environments/{environment_id}"
 
         # Create httpx client for making API calls
         basic_auth = httpx.BasicAuth(username=flink_api_key, password=flink_api_secret)
@@ -902,7 +902,7 @@ class Connection:
             merged_properties.update(properties)
 
         # Connection-level properties overlay (always set, cannot be overridden by user)
-        merged_properties["sql.current-catalog"] = self.environment
+        merged_properties["sql.current-catalog"] = self.environment_id
 
         if self._database is not None:
             merged_properties["sql.current-database"] = self._database
@@ -982,7 +982,7 @@ class Connection:
         payload = {
             "name": statement_name,
             "organization_id": self.organization_id,
-            "environment_id": self.environment,
+            "environment_id": self.environment_id,
             "spec": {
                 "statement": statement,
                 "properties": merged_properties,

--- a/src/confluent_sql/connection.py
+++ b/src/confluent_sql/connection.py
@@ -267,7 +267,10 @@ class Connection:
             # Strip trailing slash if user provided one, to ensure clean URL construction
             endpoint = endpoint.rstrip("/")
 
-        base_url = f"{endpoint}/sql/v1/organizations/{organization_id}/environments/{environment_id}"
+        base_url = (
+            f"{endpoint}/sql/v1/organizations/{organization_id}"
+            f"/environments/{environment_id}"
+        )
 
         # Create httpx client for making API calls
         basic_auth = httpx.BasicAuth(username=flink_api_key, password=flink_api_secret)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,7 @@ def connection_factory() -> Generator[ConnectionFactory, None, None]:
         *,
         flink_api_key: str | None = None,
         flink_api_secret: str | None = None,
-        environment: str | None = None,
+        environment_id: str | None = None,
         organization_id: str | None = None,
         compute_pool_id: str | None = None,
         cloud_provider: str | None = None,
@@ -65,8 +65,8 @@ def connection_factory() -> Generator[ConnectionFactory, None, None]:
             flink_api_key = os.getenv("CONFLUENT_FLINK_API_KEY", "")
         if flink_api_secret is None:
             flink_api_secret = os.getenv("CONFLUENT_FLINK_API_SECRET", "")
-        if environment is None:
-            environment = os.getenv("CONFLUENT_ENV_ID", "")
+        if environment_id is None:
+            environment_id = os.getenv("CONFLUENT_ENV_ID", "")
         if organization_id is None:
             organization_id = os.getenv("CONFLUENT_ORG_ID", "")
         if compute_pool_id is None:
@@ -84,7 +84,7 @@ def connection_factory() -> Generator[ConnectionFactory, None, None]:
         connection = connect(
             flink_api_key=flink_api_key,
             flink_api_secret=flink_api_secret,
-            environment=environment,
+            environment_id=environment_id,
             organization_id=organization_id,
             compute_pool_id=compute_pool_id,
             cloud_region=cloud_region,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -71,7 +71,7 @@ def connection(load_env_file) -> Generator[Connection, Any, None]:
     """
     flink_api_key = os.getenv("CONFLUENT_FLINK_API_KEY", "")
     flink_api_secret = os.getenv("CONFLUENT_FLINK_API_SECRET", "")
-    environment = os.getenv("CONFLUENT_ENV_ID", "")
+    environment_id = os.getenv("CONFLUENT_ENV_ID", "")
     organization_id = os.getenv("CONFLUENT_ORG_ID", "")
     compute_pool_id = os.getenv("CONFLUENT_COMPUTE_POOL_ID", "")
     cloud_provider = os.getenv("CONFLUENT_CLOUD_PROVIDER", "")
@@ -82,7 +82,7 @@ def connection(load_env_file) -> Generator[Connection, Any, None]:
         [
             flink_api_key,
             flink_api_secret,
-            environment,
+            environment_id,
             organization_id,
             compute_pool_id,
             cloud_region,
@@ -95,7 +95,7 @@ def connection(load_env_file) -> Generator[Connection, Any, None]:
     conn = confluent_sql.connect(
         flink_api_key=flink_api_key,
         flink_api_secret=flink_api_secret,
-        environment=environment,
+        environment_id=environment_id,
         organization_id=organization_id,
         compute_pool_id=compute_pool_id,
         cloud_region=cloud_region,

--- a/tests/integration/test_connection.py
+++ b/tests/integration/test_connection.py
@@ -70,7 +70,7 @@ class TestConnection:
         connection = confluent_sql.connect(
             flink_api_key=flink_api_key,
             flink_api_secret=flink_api_secret,
-            environment=environment_id,
+            environment_id=environment_id,
             organization_id=organization_id,
             compute_pool_id=compute_pool_id,
             cloud_region=cloud_region,

--- a/tests/unit/test_connection_unit.py
+++ b/tests/unit/test_connection_unit.py
@@ -285,8 +285,8 @@ class TestConnectionInit:
 class TestConnectChecks:
     """Tests for connection checks when creating a connection."""
 
-    def test_requires_environment(self, connection_factory: ConnectionFactory):
-        """Test that creating a connection without an environment raises an error."""
+    def test_requires_environment_id(self, connection_factory: ConnectionFactory):
+        """Test that creating a connection without an environment_id raises an error."""
         with pytest.raises(InterfaceError, match="Environment ID is required"):
             connection_factory(environment_id="")
 

--- a/tests/unit/test_connection_unit.py
+++ b/tests/unit/test_connection_unit.py
@@ -286,7 +286,7 @@ class TestConnectChecks:
     """Tests for connection checks when creating a connection."""
 
     def test_requires_environment_id(self, connection_factory: ConnectionFactory):
-        """Test that creating a connection without an environment_id raises an error."""
+        """Test that creating a connection without an environment ID raises an error."""
         with pytest.raises(InterfaceError, match="Environment ID is required"):
             connection_factory(environment_id="")
 

--- a/tests/unit/test_connection_unit.py
+++ b/tests/unit/test_connection_unit.py
@@ -24,7 +24,7 @@ def invalid_credential_connection() -> Connection:
     This is useful for testing connection error handling.
     """
     return connect(
-        environment="env-id",
+        environment_id="env-id",
         organization_id="org-id",
         compute_pool_id="cp-id",
         cloud_provider="aws",
@@ -112,7 +112,7 @@ def test_connection_constructor_hates_negative_pause_millis(connection_factory: 
     statement_results_page_fetch_pause_millis."""
     with pytest.raises(InterfaceError, match="result_page_fetch_pause_millis must be non-negative"):
         connection_factory(
-            environment="foo_id",
+            environment_id="foo_id",
             compute_pool_id="1234",
             organization_id="4567",
             cloud_provider="aws",
@@ -209,7 +209,7 @@ class TestDeprecatedDbnameParameter:
         """
         with pytest.warns(DeprecationWarning, match="'dbname' parameter is deprecated"):
             conn = connect(
-                environment="env-id",
+                environment_id="env-id",
                 compute_pool_id="cp-id",
                 organization_id="org-id",
                 cloud_provider="aws",
@@ -236,7 +236,7 @@ class TestDeprecatedDbnameParameter:
             match="Cannot specify both 'database' and deprecated 'dbname' parameters",
         ):
             connect(
-                environment="env-id",
+                environment_id="env-id",
                 compute_pool_id="cp-id",
                 organization_id="org-id",
                 cloud_provider="aws",
@@ -270,7 +270,7 @@ class TestConnectionInit:
             match="cloud_provider and cloud_region are required when endpoint is not provided",
         ):
             Connection(
-                environment="foo_id",
+                environment_id="foo_id",
                 compute_pool_id="1234",
                 organization_id="4567",
                 flink_api_key="valid-key",
@@ -288,17 +288,17 @@ class TestConnectChecks:
     def test_requires_environment(self, connection_factory: ConnectionFactory):
         """Test that creating a connection without an environment raises an error."""
         with pytest.raises(InterfaceError, match="Environment ID is required"):
-            connection_factory(environment="")
+            connection_factory(environment_id="")
 
     def test_requires_compute_pool_id(self, connection_factory: ConnectionFactory):
         """Test that creating a connection without a compute pool ID raises an error."""
         with pytest.raises(InterfaceError, match="Compute pool ID is required"):
-            connection_factory(environment="foo_id", compute_pool_id="")
+            connection_factory(environment_id="foo_id", compute_pool_id="")
 
     def test_requires_organization_id(self, connection_factory: ConnectionFactory):
         """Test that creating a connection without an organization ID raises an error."""
         with pytest.raises(InterfaceError, match="Organization ID is required"):
-            connection_factory(environment="foo_id", compute_pool_id="1234", organization_id="")
+            connection_factory(environment_id="foo_id", compute_pool_id="1234", organization_id="")
 
     def test_requires_cloud_provider(self, connection_factory: ConnectionFactory):
         """Test that cloud provider is required when endpoint is not provided."""
@@ -306,7 +306,7 @@ class TestConnectChecks:
             InterfaceError, match="Cloud provider is required when endpoint is not provided"
         ):
             connection_factory(
-                environment="foo_id",
+                environment_id="foo_id",
                 compute_pool_id="1234",
                 organization_id="4567",
                 cloud_provider="",
@@ -318,7 +318,7 @@ class TestConnectChecks:
             InterfaceError, match="Cloud region is required when endpoint is not provided"
         ):
             connection_factory(
-                environment="foo_id",
+                environment_id="foo_id",
                 compute_pool_id="1234",
                 organization_id="4567",
                 cloud_provider="aws",
@@ -328,7 +328,7 @@ class TestConnectChecks:
     def test_builds_endpoint_from_cloud_info(self, connection_factory: ConnectionFactory):
         """Test that when endpoint is not provided, it is built correctly from cloud info."""
         conn = connection_factory(
-            environment="env-123",
+            environment_id="env-123",
             organization_id="org-456",
             compute_pool_id="cp-789",
             cloud_provider="aws",
@@ -344,7 +344,7 @@ class TestConnectChecks:
         """Test that creating a connection without a Flink API key raises an error."""
         with pytest.raises(InterfaceError, match="Flink region API key and secret are required"):
             connection_factory(
-                environment="foo_id",
+                environment_id="foo_id",
                 compute_pool_id="1234",
                 organization_id="4567",
                 cloud_provider="aws",
@@ -356,7 +356,7 @@ class TestConnectChecks:
         """Test that creating a connection without a Flink API secret raises an error."""
         with pytest.raises(InterfaceError, match="Flink region API key and secret are required"):
             connection_factory(
-                environment="foo_id",
+                environment_id="foo_id",
                 compute_pool_id="1234",
                 organization_id="4567",
                 cloud_provider="aws",
@@ -368,7 +368,7 @@ class TestConnectChecks:
     def test_endpoint_parameter_uses_custom_endpoint(self, connection_factory: ConnectionFactory):
         """Test that providing endpoint parameter uses the custom endpoint."""
         conn = connection_factory(
-            environment="env-123",
+            environment_id="env-123",
             organization_id="org-456",
             compute_pool_id="cp-789",
             flink_api_key="test-key",
@@ -385,7 +385,7 @@ class TestConnectChecks:
     def test_endpoint_parameter_with_trailing_slash(self, connection_factory: ConnectionFactory):
         """Test that endpoint parameter with trailing slash is stripped correctly."""
         conn = connection_factory(
-            environment="env-123",
+            environment_id="env-123",
             organization_id="org-456",
             compute_pool_id="cp-789",
             flink_api_key="test-key",
@@ -406,7 +406,7 @@ class TestConnectChecks:
     def test_endpoint_parameter_without_trailing_slash(self, connection_factory: ConnectionFactory):
         """Test that endpoint parameter without trailing slash works correctly."""
         conn = connection_factory(
-            environment="env-123",
+            environment_id="env-123",
             organization_id="org-456",
             compute_pool_id="cp-789",
             flink_api_key="test-key",
@@ -435,7 +435,7 @@ class TestConnectChecks:
             ),
         ):
             connection_factory(
-                environment="env-123",
+                environment_id="env-123",
                 organization_id="org-456",
                 compute_pool_id="cp-789",
                 flink_api_key="test-key",
@@ -455,7 +455,7 @@ class TestConnectChecks:
             ),
         ):
             connection_factory(
-                environment="env-123",
+                environment_id="env-123",
                 organization_id="org-456",
                 compute_pool_id="cp-789",
                 flink_api_key="test-key",
@@ -1265,7 +1265,7 @@ def http_agent_connection_factory(
 
     def _create_with_agent(http_user_agent: str | None = None) -> Connection:
         return connection_factory(
-            environment="test-env",
+            environment_id="test-env",
             compute_pool_id="test-pool",
             organization_id="test-org",
             cloud_provider="aws",

--- a/tests/unit/test_connection_unit_properties.py
+++ b/tests/unit/test_connection_unit_properties.py
@@ -13,7 +13,7 @@ from confluent_sql.execution_mode import ExecutionMode
 def invalid_credential_connection() -> Connection:
     """A connection with invalid credentials for testing."""
     return connect(
-        environment="env-id",
+        environment_id="env-id",
         organization_id="org-id",
         compute_pool_id="cp-id",
         cloud_provider="aws",


### PR DESCRIPTION
Rename `connect(environment=)` param to `environment_id`, since we need an id here, not an environment name. Now all `connect()` and `Connection.__init__` parameters which require ids use Hungarian notation to indicate as such.

Documented as a breaking change.

Closes #92.
