### PR TITLE
put main back under development.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this dbapi driver will be documented in this file.
 
+## Unreleased
+
+
 ## 0.3.0, 2026-04-09
 
 ### Changed - Breaking

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "confluent-sql"
-version = "0.3.0"
+version = "0.4.0-pre"
 description = "DB-API v2 compliant driver for Confluent Cloud Flink SQL"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Mark main as version 0.4.0-pre and new unreleased CHANGELOG section.