### PR TITLE
[APPSEC-6902] Add --frozen flag to uv sync in Semaphore CI

### DIFF
--- a/.semaphore/publish_to_codeartifact.yml
+++ b/.semaphore/publish_to_codeartifact.yml
@@ -10,7 +10,7 @@ global_job_config:
       - checkout
       - . vault-setup
       - curl -LsSf https://astral.sh/uv/0.10.11/install.sh | sh
-      - uv sync --locked
+      - uv sync --frozen
 
 blocks:
   - name: Publish `confluent_sql` to codeartifact

--- a/.semaphore/publish_to_codeartifact.yml
+++ b/.semaphore/publish_to_codeartifact.yml
@@ -10,7 +10,7 @@ global_job_config:
       - checkout
       - . vault-setup
       - curl -LsSf https://astral.sh/uv/0.10.11/install.sh | sh
-      - uv sync
+      - uv sync --locked
 
 blocks:
   - name: Publish `confluent_sql` to codeartifact

--- a/.semaphore/publish_to_pypi.yml
+++ b/.semaphore/publish_to_pypi.yml
@@ -10,7 +10,7 @@ global_job_config:
       - checkout
       - . vault-setup
       - curl -LsSf https://astral.sh/uv/0.10.11/install.sh | sh
-      - uv sync --locked
+      - uv sync --frozen
 
 blocks:
   - name: Publish `confluent_sql` to PyPi

--- a/.semaphore/publish_to_pypi.yml
+++ b/.semaphore/publish_to_pypi.yml
@@ -10,7 +10,7 @@ global_job_config:
       - checkout
       - . vault-setup
       - curl -LsSf https://astral.sh/uv/0.10.11/install.sh | sh
-      - uv sync
+      - uv sync --locked
 
 blocks:
   - name: Publish `confluent_sql` to PyPi

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -21,7 +21,7 @@ global_job_config:
       - checkout
       - . vault-setup
       - curl -LsSf https://astral.sh/uv/0.10.11/install.sh | sh
-      - uv sync --locked
+      - uv sync --frozen
       - export VERSION=$(grep '^version' pyproject.toml | cut -d'"' -f2)
 
 blocks:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -21,7 +21,7 @@ global_job_config:
       - checkout
       - . vault-setup
       - curl -LsSf https://astral.sh/uv/0.10.11/install.sh | sh
-      - uv sync
+      - uv sync --locked
       - export VERSION=$(grep '^version' pyproject.toml | cut -d'"' -f2)
 
 blocks:


### PR DESCRIPTION
## Summary
- Adds `--frozen` flag to `uv sync` commands in all three Semaphore CI pipeline files:
  - `.semaphore/publish_to_codeartifact.yml`
  - `.semaphore/publish_to_pypi.yml`
  - `.semaphore/semaphore.yml`
- Ensures CI dependency resolution uses the lockfile without attempting to update it
- This change will prevent compromised malicious PyPI packages from immediately affecting CI jobs

## Test plan
- [ ] Verify Semaphore CI pipelines pass with `--frozen` flag
- [ ] Confirm `uv.lock` is up-to-date in the repo (if not, run `uv lock` first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)