### PR TITLE
[APPSEC-6902] Add --frozen flag to uv run in Semaphore CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -31,7 +31,7 @@ blocks:
       jobs:
         - name: "Lint, Type Check, and Test"
           commands:
-            - uv run ruff check && uv run pyright && uv run pytest -m unit --junitxml=test-results.xml
+            - uv run --frozen ruff check && uv run --frozen pyright && uv run --frozen pytest -m unit --junitxml=test-results.xml
       epilogue:
         always:
           commands:


### PR DESCRIPTION
## Summary
- Adds `--frozen` flag to `uv run` invocations in `.semaphore/semaphore.yml` (3 occurrences in one chained command)
- Ensures CI runs use the committed `uv.lock` without attempting to resolve dependencies
- This change acts as a mitigation against malicious PyPI packages being pulled into CI

## Test plan
- [ ] Verify Semaphore CI pipeline passes with `--frozen` flag
- [ ] Confirm `uv.lock` is up-to-date in the repo (if not, run `uv lock` first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)