### PR TITLE
Make the http timeout configurable

### DIFF
--- a/src/confluent_sql/connection.py
+++ b/src/confluent_sql/connection.py
@@ -48,6 +48,7 @@ def connect(  # noqa: PLR0913
     dbname: str | None = None,  # deprecated, use database parameter
     result_page_fetch_pause_millis: int = 100,
     http_user_agent: str | None = None,
+    http_timeout_secs: float | None = None,
 ) -> Connection:
     """
     Create a connection to a Confluent SQL service.
@@ -87,6 +88,9 @@ def connect(  # noqa: PLR0913
                        between 1-100 characters. Defaults to
                        "Confluent-SQL-Dbapi/v<version> (https://confluent.io; support@confluent.io)"
                        where version is from __version__.py
+        http_timeout_secs: Timeout in seconds for HTTP requests made by the underlying httpx
+                       client. Must be a positive number. If None (default), the httpx default
+                       of 5 seconds applies to connect, read, write, and pool operations.
 
     Returns:
         A Connection object representing the database connection
@@ -144,6 +148,7 @@ def connect(  # noqa: PLR0913
         database=database or dbname,  # dbname is deprecated.
         statement_results_page_fetch_pause_millis=result_page_fetch_pause_millis,
         http_user_agent=http_user_agent,
+        http_timeout_secs=http_timeout_secs,
     )
 
 
@@ -181,6 +186,7 @@ class Connection:
     _database: str | None
     _client: httpx.Client
     _http_user_agent: str
+    _http_timeout_secs: float | None
 
     _row_type_registry: RowTypeRegistry
     """Registry for user-defined row types, see register_row_type()."""
@@ -202,6 +208,7 @@ class Connection:
         database: str | None = None,
         statement_results_page_fetch_pause_millis: int = 100,
         http_user_agent: str | None = None,
+        http_timeout_secs: float | None = None,
     ):
         """
         Initialize a new connection to a Confluent SQL service.
@@ -231,6 +238,9 @@ class Connection:
             http_user_agent: User-Agent header for HTTP requests. String, 1-100 chars.
                            Defaults to the value of DEFAULT_USER_AGENT, which includes the
                            driver name/version, documentation URL, and support email.
+            http_timeout_secs: Timeout in seconds applied to the underlying httpx client.
+                           Must be a positive number. If None (default), the httpx default
+                           of 5 seconds applies.
         """
         self.environment_id = environment_id
         self.compute_pool_id = compute_pool_id
@@ -254,6 +264,22 @@ class Connection:
             http_user_agent if http_user_agent is not None else self.DEFAULT_USER_AGENT
         )
 
+        if http_timeout_secs is not None:
+            # Reject bool explicitly: bool is a subclass of int in Python, but a True/False
+            # value here is almost certainly a programming error rather than a valid timeout.
+            if isinstance(http_timeout_secs, bool) or not isinstance(
+                http_timeout_secs, (int, float)
+            ):
+                raise InterfaceError(
+                    f"http_timeout_secs must be a number, "
+                    f"got {type(http_timeout_secs).__name__}"
+                )
+            if http_timeout_secs <= 0:
+                raise InterfaceError(
+                    f"http_timeout_secs must be positive, got {http_timeout_secs}"
+                )
+        self._http_timeout_secs = http_timeout_secs
+
         if not endpoint and not (cloud_provider and cloud_region):
             raise InterfaceError(
                 "cloud_provider and cloud_region are required when endpoint is not provided"
@@ -274,14 +300,17 @@ class Connection:
 
         # Create httpx client for making API calls
         basic_auth = httpx.BasicAuth(username=flink_api_key, password=flink_api_secret)
-        self._client = httpx.Client(
-            auth=basic_auth,
-            base_url=base_url,
-            headers={
+        client_kwargs: dict[str, Any] = {
+            "auth": basic_auth,
+            "base_url": base_url,
+            "headers": {
                 "Content-Type": "application/json",
                 "User-Agent": self._http_user_agent,
             },
-        )
+        }
+        if self._http_timeout_secs is not None:
+            client_kwargs["timeout"] = self._http_timeout_secs
+        self._client = httpx.Client(**client_kwargs)
 
         self._row_type_registry = RowTypeRegistry()
 
@@ -802,6 +831,14 @@ class Connection:
             True if the connection is closed, False otherwise
         """
         return self._closed
+
+    @property
+    def http_timeout_secs(self) -> float | None:
+        """
+        Get the configured timeout (in seconds) for HTTP requests, or None if the
+        httpx default (5 seconds) is in effect.
+        """
+        return self._http_timeout_secs
 
     @property
     def http_user_agent(self) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,6 +59,7 @@ def connection_factory() -> Generator[ConnectionFactory, None, None]:
         database: str | None = None,
         result_page_fetch_pause_millis: int = 100,
         http_user_agent: str | None = None,
+        http_timeout_secs: float | None = None,
         endpoint: str | None = None,
     ) -> Connection:
         if flink_api_key is None:
@@ -92,6 +93,7 @@ def connection_factory() -> Generator[ConnectionFactory, None, None]:
             database=database,
             result_page_fetch_pause_millis=result_page_fetch_pause_millis,
             http_user_agent=http_user_agent,
+            http_timeout_secs=http_timeout_secs,
             endpoint=endpoint,
         )
 

--- a/tests/unit/test_connection_unit.py
+++ b/tests/unit/test_connection_unit.py
@@ -1491,6 +1491,94 @@ class TestHttpUserAgentProperty:
 
 
 @pytest.mark.unit
+class TestHttpTimeoutSecs:
+    """Tests for the http_timeout_secs constructor parameter and property."""
+
+    def test_default_is_none_and_httpx_default_applies(
+        self, invalid_credential_connection: Connection
+    ):
+        """When not provided, the property is None and the httpx default (5s) is used."""
+        assert invalid_credential_connection.http_timeout_secs is None
+        # httpx's default Timeout(timeout=5.0) is wrapped in a Timeout object on the client.
+        assert invalid_credential_connection._client.timeout == httpx.Timeout(5.0)
+
+    @pytest.mark.parametrize("timeout_value", [0.5, 1, 10, 30.0, 120])
+    def test_custom_timeout_via_constructor(
+        self, connection_factory: ConnectionFactory, timeout_value
+    ):
+        """A custom timeout is stored on the connection and applied to the httpx client."""
+        conn = connection_factory(
+            environment_id="env-id",
+            organization_id="org-id",
+            compute_pool_id="cp-id",
+            cloud_provider="aws",
+            cloud_region="us-east-1",
+            flink_api_key="key",
+            flink_api_secret="secret",
+            http_timeout_secs=timeout_value,
+        )
+        assert conn.http_timeout_secs == timeout_value
+        # httpx wraps the timeout into a Timeout(connect, read, write, pool) object.
+        assert conn._client.timeout == httpx.Timeout(timeout_value)
+
+    @pytest.mark.parametrize(
+        "invalid_value,expected_error",
+        [
+            (0, "http_timeout_secs must be positive, got 0"),
+            (-1, "http_timeout_secs must be positive, got -1"),
+            (-0.5, "http_timeout_secs must be positive, got -0.5"),
+        ],
+    )
+    def test_rejects_non_positive(
+        self,
+        connection_factory: ConnectionFactory,
+        invalid_value,
+        expected_error,
+    ):
+        """Zero and negative values are rejected."""
+        with pytest.raises(InterfaceError, match=expected_error):
+            connection_factory(
+                environment_id="env-id",
+                organization_id="org-id",
+                compute_pool_id="cp-id",
+                cloud_provider="aws",
+                cloud_region="us-east-1",
+                flink_api_key="key",
+                flink_api_secret="secret",
+                http_timeout_secs=invalid_value,
+            )
+
+    @pytest.mark.parametrize(
+        "invalid_value,expected_error",
+        [
+            ("5", "http_timeout_secs must be a number, got str"),
+            ([5], "http_timeout_secs must be a number, got list"),
+            ({"secs": 5}, "http_timeout_secs must be a number, got dict"),
+            (True, "http_timeout_secs must be a number, got bool"),
+            (False, "http_timeout_secs must be a number, got bool"),
+        ],
+    )
+    def test_rejects_non_numeric(
+        self,
+        connection_factory: ConnectionFactory,
+        invalid_value,
+        expected_error,
+    ):
+        """Non-numeric types (including bool) are rejected."""
+        with pytest.raises(InterfaceError, match=expected_error):
+            connection_factory(
+                environment_id="env-id",
+                organization_id="org-id",
+                compute_pool_id="cp-id",
+                cloud_provider="aws",
+                cloud_region="us-east-1",
+                flink_api_key="key",
+                flink_api_secret="secret",
+                http_timeout_secs=invalid_value,
+            )
+
+
+@pytest.mark.unit
 class TestComputePoolIdParameter:
     """Test the compute_pool_id parameter for Connection methods."""
 


### PR DESCRIPTION
This PR adds an option to the connection object to configure the timeout for http connections, which defaults to 5 seconds