### PR TITLE
Http error code in delete_statement

### DIFF
--- a/src/confluent_sql/connection.py
+++ b/src/confluent_sql/connection.py
@@ -813,7 +813,9 @@ class Connection:
             response.raise_for_status()
         except httpx.HTTPStatusError as e:
             if e.response.status_code != 404:
-                raise OperationalError("Error deleting statement") from e
+                raise OperationalError(
+                    "Error deleting statement", http_status_code=e.response.status_code
+                ) from e
             # If the response is 404, it means we don't need to delete the statement.
             logger.info(f"Statement '{statement_name}' not found while deleting, ignoring")
 

--- a/tests/unit/test_connection_unit.py
+++ b/tests/unit/test_connection_unit.py
@@ -153,8 +153,9 @@ class TestConnectionDeleteStatementErrors:
         response_mock.raise_for_status = raise_internal_server_error
         request_mock.return_value = response_mock
 
-        with pytest.raises(OperationalError, match="Error deleting statement"):
+        with pytest.raises(OperationalError, match="Error deleting statement") as exc_info:
             invalid_credential_connection.delete_statement("statement-with-error")
+        assert exc_info.value.http_status_code == 500
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Add `http_status_code` to the operational error raised by `delete_statement`, and modify an existing test to assert it works.