### PR TITLE
Relax and extend `Connection.list_statements()`

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -293,7 +293,7 @@ This simplifies your code by eliminating manual polling loops, but your applicat
 
 ### Finding Existing Statements
 
-List statements by label (useful for batch operations):
+List statements—optionally filtered by label, compute pool, and/or name substring (useful for batch operations):
 
 ```python
 # Find all statements with a specific label

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -109,28 +109,29 @@ print(statement.name)  # "create-summary-table"
 
 **Name Uniqueness:**
 
-Statement names **must be unique within the compute pool** they are submitted to. If you attempt to submit a statement with a name that already exists in the same compute pool, the server will reject it with an error. This means:
+Statement names **must be unique within the environment** they are submitted to. If you attempt to submit a statement with a name that already exists anywhere in the same environment—even from a connection on a different compute pool—the server will reject it with an error. This means:
 
-- Auto-generated names are guaranteed unique per compute pool
-- If using explicit names, you must ensure they don't conflict with existing statements
+- Auto-generated names are guaranteed unique within the environment
+- If using explicit names, you must ensure they don't conflict with any existing statement in the environment
 - After deleting a statement, its name becomes available for reuse
-- Names are scoped to the compute pool, not globally—different compute pools can have statements with the same name
+- Names are scoped to the environment, not to a compute pool—a name in use anywhere in the environment cannot be reused from another compute pool
 
 ```python
-# This will work: same name in different compute pools
+# This will fail: the name is already in use elsewhere in the environment,
+# even though the second connection targets a different compute pool.
 pool_a_cursor = connection_pool_a.cursor()
 pool_a_cursor.execute(
     "SELECT * FROM data",
-    statement_name="my-query"  # OK in pool A
+    statement_name="my-query"  # OK: first use of this name in the environment
 )
 
 pool_b_cursor = connection_pool_b.cursor()
 pool_b_cursor.execute(
     "SELECT * FROM data",
-    statement_name="my-query"  # OK in pool B (different pool)
+    statement_name="my-query"  # ❌ Error: name already exists in the environment
 )
 
-# This will fail: same name in the same compute pool
+# This also fails for the same reason, within a single compute pool:
 cursor1 = connection.cursor()
 cursor1.execute("SELECT * FROM table1", statement_name="my-query")
 
@@ -167,7 +168,7 @@ Labels allow you to organize statements logically without requiring unique names
 
 ### Statement Persistence and Recovery
 
-Statements persist on the server independently of your client connection, but are **scoped to the compute pool** where they were submitted. Statements can only be found, monitored, and recovered within the same compute pool:
+Statements persist on the server independently of your client connection, and are **scoped to the environment** (organization + environment) they were submitted to—not to the compute pool or the submitting connection. Any connection to the same environment can find, monitor, and recover them, regardless of which compute pool ran them (narrow to a single pool with the `compute_pool_id` filter on `list_statements()` when you want pool-level isolation):
 
 1. **Create a statement with a name** for recovery:
 
@@ -180,9 +181,9 @@ Statements persist on the server independently of your client connection, but ar
    )
    ```
 
-2. **Recover it from another connection in the same compute pool:**
+2. **Recover it from another connection in the same environment:**
    ```python
-   # In a different Python process or session (same compute pool)
+   # In a different Python process or session (same environment)
    statements = connection.list_statements(label="daily-jobs")
    for stmt in statements:
        if stmt.name == "daily-summary-job":

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this dbapi driver will be documented in this file.
 
 ## Unreleased
 
+### Changed
+
+- `Connection.list_statements()`:
+  - New optional parameter `compute_pool_id` to list statements only in a single compute pool (otherwise environment-wide).
+  - New optional parameter `name_regex: str | re.Pattern` to filter statement names client-side.
+  - Existing parameter `label` is now optional.
+
 ## 0.3.1, 2026-05-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this dbapi driver will be documented in this file.
 
 - `Connection.list_statements()`:
   - New optional parameter `compute_pool_id` to list statements only in a single compute pool (otherwise environment-wide).
-  - New optional parameter `name_regex: str | re.Pattern` to filter statement names client-side.
+  - New optional parameter `name_contains: str` to filter statements server-side to those whose name contains the given substring (case-sensitive).
   - Existing parameter `label` is now optional.
 
 ## 0.3.1, 2026-05-21

--- a/DBAPI_EXTENSIONS.md
+++ b/DBAPI_EXTENSIONS.md
@@ -455,11 +455,23 @@ for stmt in statements:
 
 ### Finding and Deleting Statements
 
-**`list_statements()` - Find statements by label**
+**`list_statements()` - Find statements, optionally filtered**
+
+Called with no arguments, returns every statement in the environment. Three optional,
+server-side filters narrow the results and combine with AND semantics:
+
+- `label` — statements carrying the given end-user label.
+- `compute_pool_id` — statements in a specific compute pool.
+- `name_contains` — statements whose name contains the given substring (case-sensitive).
 
 ```python
-# Find all statements with a specific label
+# Every statement in the environment
+statements = connection.list_statements()
+
+# Narrow by label, compute pool, and/or name substring (filters AND together)
 statements = connection.list_statements(label="daily-backups", page_size=100)
+statements = connection.list_statements(compute_pool_id="lfcp-789012")
+statements = connection.list_statements(name_contains="orders-stream")
 
 for statement in statements:
     print(f"Statement: {statement.name}")

--- a/src/confluent_sql/connection.py
+++ b/src/confluent_sql/connection.py
@@ -8,7 +8,6 @@ connections to Confluent SQL services.
 from __future__ import annotations
 
 import logging
-import re
 import uuid
 import warnings
 from collections import namedtuple
@@ -665,15 +664,14 @@ class Connection:
         *,
         label: str | None = None,
         compute_pool_id: str | None = None,
-        name_regex: str | re.Pattern[str] | None = None,
+        name_contains: str | None = None,
         page_size: int = 100,
     ) -> list[Statement]:
         """Return Statement objects, optionally narrowed by label, compute pool, and/or name.
 
         With no filters supplied, every statement in the environment is returned. The filters
-        are combinable (AND semantics): `label` and `compute_pool_id` are applied server-side
-        via query parameters, then `name_regex` filters the fetched results client-side.
-        Pagination is handled automatically.
+        are combinable (AND semantics) and all applied server-side via query parameters;
+        pagination is handled automatically.
 
         Args:
             label: Optional label to filter statements by. You can provide either:
@@ -682,9 +680,10 @@ class Connection:
                    - The full label with prefix (e.g., "user.confluent.io/my-batch-job")
             compute_pool_id: Optional compute pool ID to filter by, applied server-side via the
                             `spec.compute_pool_id` query parameter.
-            name_regex: Optional regular expression (a `str` or pre-compiled `re.Pattern`) used
-                       to filter statements by name client-side. Matching uses `re.search`
-                       (substring) semantics, so anchor with `^`/`$` for a tighter match.
+            name_contains: Optional substring to filter statement names by, applied server-side
+                          via the `statement_name_search_query` query parameter. Matching is a
+                          case-sensitive substring test (no regex / anchoring). Supplying this
+                          forces the result set to be time-ordered (see implementation note).
             page_size: Number of statements to fetch per API request (default: 100).
                       The method will automatically paginate through all results.
 
@@ -705,8 +704,8 @@ class Connection:
             # Filter by compute pool (server-side)
             statements = connection.list_statements(compute_pool_id="lfcp-789012")
 
-            # Filter by statement name (client-side substring match)
-            statements = connection.list_statements(name_regex=r"^dbapi-")
+            # Filter by statement name (server-side substring match)
+            statements = connection.list_statements(name_contains="dbapi-")
 
             # Delete all matching statements
             for stmt in statements:
@@ -727,16 +726,12 @@ class Connection:
         if compute_pool_id is not None:
             parameters["spec.compute_pool_id"] = compute_pool_id
 
-        # re.compile is idempotent on an already-compiled Pattern, so both a raw
-        # string and a pre-compiled pattern are accepted.
-        name_pattern: re.Pattern[str] | None = (
-            re.compile(name_regex) if name_regex is not None else None
-        )
-
-        # Re-express `name_pattern` as a predicate function over statement-name strings:
-        #   * a user-supplied pattern matches via re.search (substring);
-        #   * otherwise an empty pattern matches every name.
-        name_matches = (name_pattern or re.compile("")).search
+        if name_contains is not None:
+            parameters["statement_name_search_query"] = name_contains
+            # The server only honors statement_name_search_query when time_ordered=true is also
+            # present; without it the search term is silently ignored and every statement is
+            # returned. Verified empirically against /sql/v1 -- see the originating PR.
+            parameters["time_ordered"] = "true"
 
         statements: list[Statement] = []
 
@@ -746,11 +741,7 @@ class Connection:
             response = self._request("/statements", params=parameters)
             resp_json = response.json()
             statements_json = resp_json.get("data", [])
-            statements.extend(
-                Statement.from_response(self, s)
-                for s in statements_json
-                if name_matches(s["name"])
-            )
+            statements.extend(Statement.from_response(self, s) for s in statements_json)
 
             # Check if there are more pages to fetch based on the presence of a 'next' link in the
             # response metadata. The 'next' value will be an entire URL, but we just need to extract

--- a/src/confluent_sql/connection.py
+++ b/src/confluent_sql/connection.py
@@ -8,6 +8,7 @@ connections to Confluent SQL services.
 from __future__ import annotations
 
 import logging
+import re
 import uuid
 import warnings
 from collections import namedtuple
@@ -659,61 +660,97 @@ class Connection:
 
         return cur.statement
 
-    def list_statements(self, *, label: str, page_size: int = 100) -> list[Statement]:
-        """Return a list of Statement objects for statements with the given label.
+    def list_statements(
+        self,
+        *,
+        label: str | None = None,
+        compute_pool_id: str | None = None,
+        name_regex: str | re.Pattern[str] | None = None,
+        page_size: int = 100,
+    ) -> list[Statement]:
+        """Return Statement objects, optionally narrowed by label, compute pool, and/or name.
 
-        This method retrieves all statements that were created with the specified label,
-        which is useful for managing groups of related statements. The method handles
-        pagination automatically to retrieve all matching statements.
+        With no filters supplied, every statement in the environment is returned. The filters
+        are combinable (AND semantics): `label` and `compute_pool_id` are applied server-side
+        via query parameters, then `name_regex` filters the fetched results client-side.
+        Pagination is handled automatically.
 
         Args:
-            label: The label to filter statements by. You can provide either:
+            label: Optional label to filter statements by. You can provide either:
                    - Just the label value (e.g., "my-batch-job") - the "user.confluent.io/"
                      prefix will be added automatically
                    - The full label with prefix (e.g., "user.confluent.io/my-batch-job")
+            compute_pool_id: Optional compute pool ID to filter by, applied server-side via the
+                            `spec.compute_pool_id` query parameter.
+            name_regex: Optional regular expression (a `str` or pre-compiled `re.Pattern`) used
+                       to filter statements by name client-side. Matching uses `re.search`
+                       (substring) semantics, so anchor with `^`/`$` for a tighter match.
             page_size: Number of statements to fetch per API request (default: 100).
                       The method will automatically paginate through all results.
 
         Returns:
-            A list of Statement objects that have the specified label. Returns an
-            empty list if no statements match the label.
+            A list of matching Statement objects. Returns an empty list if nothing matches.
 
         Raises:
             OperationalError: If the API request fails
 
         Example:
-            # Submit statements with a label
-            cursor.execute("SELECT * FROM users", statement_labels=["daily-report"])
-            cursor.execute("SELECT * FROM orders", statement_labels=["daily-report"])
+            # List every statement in the environment
+            statements = connection.list_statements()
 
-            # Later, retrieve all statements with that label
+            # Submit statements with a label, then retrieve them
+            cursor.execute("SELECT * FROM users", statement_labels=["daily-report"])
             statements = connection.list_statements(label="daily-report")
 
-            # Delete all statements with the label
+            # Filter by compute pool (server-side)
+            statements = connection.list_statements(compute_pool_id="lfcp-789012")
+
+            # Filter by statement name (client-side substring match)
+            statements = connection.list_statements(name_regex=r"^dbapi-")
+
+            # Delete all matching statements
             for stmt in statements:
                 connection.delete_statement(stmt)
         """
 
-        if not label.startswith(STATEMENT_LABEL_PREFIX):
-            # Append prefix and make it a label selector for the API query parameter. The API
-            # expects the full label key, which includes the prefix, but we want to allow users
-            # to filter by just the end-user portion of the label.
-            adjusted_label_filter = f"{STATEMENT_LABEL_PREFIX}{label}=true"
-        else:
-            adjusted_label_filter = f"{label}=true"
+        # Server-side filters: only include a query parameter when its filter was supplied.
+        parameters: dict[str, str | int] = {"page_size": page_size}
+        if label is not None:
+            if not label.startswith(STATEMENT_LABEL_PREFIX):
+                # Append prefix and make it a label selector for the API query parameter. The API
+                # expects the full label key, which includes the prefix, but we want to allow
+                # users to filter by just the end-user portion of the label.
+                parameters["label_selector"] = f"{STATEMENT_LABEL_PREFIX}{label}=true"
+            else:
+                parameters["label_selector"] = f"{label}=true"
+
+        if compute_pool_id is not None:
+            parameters["spec.compute_pool_id"] = compute_pool_id
+
+        # re.compile is idempotent on an already-compiled Pattern, so both a raw
+        # string and a pre-compiled pattern are accepted.
+        name_pattern: re.Pattern[str] | None = (
+            re.compile(name_regex) if name_regex is not None else None
+        )
+
+        # Reëxpress `name_pattern` as a predicate function over statement-name strings:
+        #   * a user-supplied pattern matches via re.search (substring);
+        #   * otherwise an empty pattern matches every name.
+        name_matches = (name_pattern or re.compile("")).search
 
         statements: list[Statement] = []
 
         has_more_pages = True
         next_page_token: str | None = None
-        # Use the `label_selector` query parameter to filter statements by label
-        # on the server side.
-        parameters = {"label_selector": adjusted_label_filter, "page_size": page_size}
         while has_more_pages:
             response = self._request("/statements", params=parameters)
             resp_json = response.json()
             statements_json = resp_json.get("data", [])
-            statements.extend(Statement.from_response(self, s) for s in statements_json)
+            statements.extend(
+                Statement.from_response(self, s)
+                for s in statements_json
+                if name_matches(s.get("name", ""))
+            )
 
             # Check if there are more pages to fetch based on the presence of a 'next' link in the
             # response metadata. The 'next' value will be an entire URL, but we just need to extract

--- a/src/confluent_sql/connection.py
+++ b/src/confluent_sql/connection.py
@@ -749,14 +749,14 @@ class Connection:
             statements.extend(
                 Statement.from_response(self, s)
                 for s in statements_json
-                if name_matches(s.get("name", ""))
+                if name_matches(s["name"])
             )
 
             # Check if there are more pages to fetch based on the presence of a 'next' link in the
             # response metadata. The 'next' value will be an entire URL, but we just need to extract
             # the page token from it for the next request.
             next_page_token = self._get_next_page_token(resp_json.get("metadata", {}).get("next"))
-            if next_page_token:
+            if next_page_token is not None:
                 parameters["page_token"] = next_page_token
             has_more_pages = next_page_token is not None
 

--- a/src/confluent_sql/connection.py
+++ b/src/confluent_sql/connection.py
@@ -756,7 +756,7 @@ class Connection:
             # response metadata. The 'next' value will be an entire URL, but we just need to extract
             # the page token from it for the next request.
             next_page_token = self._get_next_page_token(resp_json.get("metadata", {}).get("next"))
-            if next_page_token is not None:
+            if next_page_token:
                 parameters["page_token"] = next_page_token
             has_more_pages = next_page_token is not None
 
@@ -1241,7 +1241,9 @@ class Connection:
         # We can parse it to extract the page_token value.
         parsed = httpx.URL(next_url)
         page_token = parsed.params.get("page_token")
-        return page_token
+        # Collapse an empty/absent token to None: list_statements' pagination loop terminates on
+        # `next_page_token is not None`, so an empty string would spin it forever.
+        return page_token or None
 
 
 class RowTypeRegistry:

--- a/src/confluent_sql/connection.py
+++ b/src/confluent_sql/connection.py
@@ -733,7 +733,7 @@ class Connection:
             re.compile(name_regex) if name_regex is not None else None
         )
 
-        # Reëxpress `name_pattern` as a predicate function over statement-name strings:
+        # Re-express `name_pattern` as a predicate function over statement-name strings:
         #   * a user-supplied pattern matches via re.search (substring);
         #   * otherwise an empty pattern matches every name.
         name_matches = (name_pattern or re.compile("")).search

--- a/tests/integration/test_cursor.py
+++ b/tests/integration/test_cursor.py
@@ -61,6 +61,44 @@ class TestCursor:
         # Cleanup.
         connection.delete_statement(statement)
 
+    def test_cursor_execute_and_find_with_name_contains(
+        self, cursor: Cursor, connection: Connection
+    ):
+        """Prove the server-side `statement_name_search_query` substring filter works end-to-end.
+
+        Submits a statement whose name embeds a unique token, then confirms `name_contains`:
+          * finds it by a unique substring of the name,
+          * is case-sensitive (an upper-cased prefix matches nothing), and
+          * returns nothing for an unrelated token.
+        The case-sensitivity assertion guards the discovered server semantics -- and would also
+        fail loudly if list_statements ever stopped sending the required `time_ordered=true`,
+        since without it the server ignores the search term and returns every statement."""
+        token = uuid4().hex
+        prefix = "test-name-contains"
+        name = f"{prefix}-{token}".lower()
+        cursor.execute(SINGLE_COLUMN_QUERY, statement_name=name)
+
+        statement = cursor._statement
+        assert statement is not None
+        assert statement.name == name
+
+        # A substring unique to this statement's name finds it server-side.
+        statements = connection.list_statements(name_contains=token)
+        assert [s.name for s in statements] == [name]
+
+        # Matching is case-sensitive: the upper-cased prefix matches nothing (the real name is
+        # lower-cased). If time_ordered=true were dropped, the server would ignore the search
+        # term and return every statement -- this assertion would then fail.
+        statements = connection.list_statements(name_contains=prefix.upper())
+        assert all(s.name != name for s in statements)
+
+        # An unrelated token matches nothing -- the server, not the client, did the filtering.
+        statements = connection.list_statements(name_contains=uuid4().hex)
+        assert all(s.name != name for s in statements)
+
+        # Cleanup.
+        connection.delete_statement(statement)
+
     def test_cursor_execute_with_multiple_labels(self, cursor: Cursor, connection: Connection):
         """Test submitting statement with multiple labels and verifying all are present."""
         label1 = f"test-label-1-{uuid4()}"

--- a/tests/unit/test_connection_unit.py
+++ b/tests/unit/test_connection_unit.py
@@ -1,5 +1,4 @@
 import copy
-import re
 from collections import namedtuple
 from dataclasses import dataclass
 from typing import NamedTuple
@@ -891,50 +890,49 @@ class TestConnectionListStatements:
             },
         )
 
-    @pytest.mark.parametrize(
-        ("name_regex", "expected_names"),
-        [
-            (r"report", ["report-a", "daily-report"]),
-            (re.compile(r"report"), ["report-a", "daily-report"]),
-            (r"^report", ["report-a"]),
-            (r"orders$", ["orders"]),
-        ],
-    )
-    def test_list_statements_name_regex_filters_client_side(
+    def test_list_statements_name_contains_sent_server_side(
         self,
         invalid_credential_connection: Connection,
         statement_response_factory: StatementResponseFactory,
         mocker,
-        name_regex: str | re.Pattern[str],
-        expected_names: list[str],
     ):
-        """name_regex filters fetched results by Statement.name using re.search semantics,
-        accepting either a raw string or a pre-compiled pattern."""
+        """name_contains is forwarded verbatim as the statement_name_search_query query param,
+        accompanied by time_ordered=true (the server ignores the search term without it). The
+        server does the substring matching, so fetched results are returned as-is."""
         mock_response = Mock()
         mock_response.json.return_value = {
             "data": [
                 statement_response_factory(name="report-a"),
                 statement_response_factory(name="daily-report"),
-                statement_response_factory(name="orders"),
             ],
             "metadata": {},
         }
 
-        mocker.patch.object(
+        request_mock = mocker.patch.object(
             invalid_credential_connection._client, "request", return_value=mock_response
         )
 
-        statements = invalid_credential_connection.list_statements(name_regex=name_regex)
+        statements = invalid_credential_connection.list_statements(name_contains="report")
 
-        assert [s.name for s in statements] == expected_names
+        request_mock.assert_called_once_with(
+            "GET",
+            "/statements",
+            params={
+                "page_size": 100,
+                "statement_name_search_query": "report",
+                "time_ordered": "true",
+            },
+        )
+        # Whatever the server returns is returned verbatim -- no client-side re-filtering.
+        assert [s.name for s in statements] == ["report-a", "daily-report"]
 
-    def test_list_statements_name_regex_not_sent_to_server(
+    def test_list_statements_all_three_filters_combined(
         self,
         invalid_credential_connection: Connection,
         statement_response_factory: StatementResponseFactory,
         mocker,
     ):
-        """name_regex is a client-side filter -- it must never be sent as a query param."""
+        """label, compute_pool_id, and name_contains all narrow server-side in one request."""
         mock_response = Mock()
         mock_response.json.return_value = {
             "data": [statement_response_factory(name="report-a")],
@@ -945,52 +943,10 @@ class TestConnectionListStatements:
             invalid_credential_connection._client, "request", return_value=mock_response
         )
 
-        invalid_credential_connection.list_statements(name_regex=r"report")
-
-        request_mock.assert_called_once_with(
-            "GET",
-            "/statements",
-            params={"page_size": 100},
-        )
-
-    def test_list_statements_invalid_name_regex_fails_before_fetch(
-        self,
-        invalid_credential_connection: Connection,
-        mocker,
-    ):
-        """An un-compilable name_regex string is rejected before any API request is made,
-        so the user learns of their typo immediately rather than after paginating."""
-        request_mock = mocker.patch.object(invalid_credential_connection._client, "request")
-
-        with pytest.raises(re.error):
-            invalid_credential_connection.list_statements(name_regex="[unterminated")
-
-        request_mock.assert_not_called()
-
-    def test_list_statements_all_three_filters_combined(
-        self,
-        invalid_credential_connection: Connection,
-        statement_response_factory: StatementResponseFactory,
-        mocker,
-    ):
-        """label + compute_pool_id narrow server-side; name_regex filters the result set."""
-        mock_response = Mock()
-        mock_response.json.return_value = {
-            "data": [
-                statement_response_factory(name="report-a"),
-                statement_response_factory(name="orders"),
-            ],
-            "metadata": {},
-        }
-
-        request_mock = mocker.patch.object(
-            invalid_credential_connection._client, "request", return_value=mock_response
-        )
-
         statements = invalid_credential_connection.list_statements(
             label="daily-report",
             compute_pool_id="lfcp-xyz",
-            name_regex=r"report",
+            name_contains="report",
         )
 
         request_mock.assert_called_once_with(
@@ -1000,6 +956,8 @@ class TestConnectionListStatements:
                 "page_size": 100,
                 "label_selector": "user.confluent.io/daily-report=true",
                 "spec.compute_pool_id": "lfcp-xyz",
+                "statement_name_search_query": "report",
+                "time_ordered": "true",
             },
         )
         assert [s.name for s in statements] == ["report-a"]

--- a/tests/unit/test_connection_unit.py
+++ b/tests/unit/test_connection_unit.py
@@ -1,4 +1,5 @@
 import copy
+import re
 from collections import namedtuple
 from dataclasses import dataclass
 from typing import NamedTuple
@@ -797,6 +798,202 @@ class TestConnectionListStatements:
         # Verify label_selector is not double-prefixed
         call_params = request_mock.call_args[1]["params"]
         assert call_params["label_selector"] == "user.confluent.io/already-prefixed=true"
+
+    def test_list_statements_no_filters_lists_all(
+        self,
+        invalid_credential_connection: Connection,
+        statement_response_factory: StatementResponseFactory,
+        mocker,
+    ):
+        """With no filters, list_statements sends only page_size and returns everything."""
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "data": [statement_response_factory(name="stmt-1")],
+            "metadata": {},
+        }
+
+        request_mock = mocker.patch.object(
+            invalid_credential_connection._client, "request", return_value=mock_response
+        )
+
+        statements = invalid_credential_connection.list_statements()
+
+        # No label_selector, no compute pool filter -- just pagination.
+        request_mock.assert_called_once_with(
+            "GET",
+            "/statements",
+            params={"page_size": 100},
+        )
+        assert [s.name for s in statements] == ["stmt-1"]
+
+    def test_list_statements_compute_pool_only(
+        self,
+        invalid_credential_connection: Connection,
+        statement_response_factory: StatementResponseFactory,
+        mocker,
+    ):
+        """compute_pool_id is sent server-side as the spec.compute_pool_id query param."""
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "data": [statement_response_factory()],
+            "metadata": {},
+        }
+
+        request_mock = mocker.patch.object(
+            invalid_credential_connection._client, "request", return_value=mock_response
+        )
+
+        invalid_credential_connection.list_statements(compute_pool_id="lfcp-xyz")
+
+        request_mock.assert_called_once_with(
+            "GET",
+            "/statements",
+            params={"page_size": 100, "spec.compute_pool_id": "lfcp-xyz"},
+        )
+
+    def test_list_statements_label_and_compute_pool_combined(
+        self,
+        invalid_credential_connection: Connection,
+        statement_response_factory: StatementResponseFactory,
+        mocker,
+    ):
+        """label and compute_pool_id both narrow server-side, in one request."""
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "data": [statement_response_factory()],
+            "metadata": {},
+        }
+
+        request_mock = mocker.patch.object(
+            invalid_credential_connection._client, "request", return_value=mock_response
+        )
+
+        invalid_credential_connection.list_statements(
+            label="daily-report", compute_pool_id="lfcp-xyz"
+        )
+
+        request_mock.assert_called_once_with(
+            "GET",
+            "/statements",
+            params={
+                "page_size": 100,
+                "label_selector": "user.confluent.io/daily-report=true",
+                "spec.compute_pool_id": "lfcp-xyz",
+            },
+        )
+
+    @pytest.mark.parametrize(
+        ("name_regex", "expected_names"),
+        [
+            (r"report", ["report-a", "daily-report"]),
+            (re.compile(r"report"), ["report-a", "daily-report"]),
+            (r"^report", ["report-a"]),
+            (r"orders$", ["orders"]),
+        ],
+    )
+    def test_list_statements_name_regex_filters_client_side(
+        self,
+        invalid_credential_connection: Connection,
+        statement_response_factory: StatementResponseFactory,
+        mocker,
+        name_regex: str | re.Pattern[str],
+        expected_names: list[str],
+    ):
+        """name_regex filters fetched results by Statement.name using re.search semantics,
+        accepting either a raw string or a pre-compiled pattern."""
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "data": [
+                statement_response_factory(name="report-a"),
+                statement_response_factory(name="daily-report"),
+                statement_response_factory(name="orders"),
+            ],
+            "metadata": {},
+        }
+
+        mocker.patch.object(
+            invalid_credential_connection._client, "request", return_value=mock_response
+        )
+
+        statements = invalid_credential_connection.list_statements(name_regex=name_regex)
+
+        assert [s.name for s in statements] == expected_names
+
+    def test_list_statements_name_regex_not_sent_to_server(
+        self,
+        invalid_credential_connection: Connection,
+        statement_response_factory: StatementResponseFactory,
+        mocker,
+    ):
+        """name_regex is a client-side filter -- it must never be sent as a query param."""
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "data": [statement_response_factory(name="report-a")],
+            "metadata": {},
+        }
+
+        request_mock = mocker.patch.object(
+            invalid_credential_connection._client, "request", return_value=mock_response
+        )
+
+        invalid_credential_connection.list_statements(name_regex=r"report")
+
+        request_mock.assert_called_once_with(
+            "GET",
+            "/statements",
+            params={"page_size": 100},
+        )
+
+    def test_list_statements_invalid_name_regex_fails_before_fetch(
+        self,
+        invalid_credential_connection: Connection,
+        mocker,
+    ):
+        """An un-compilable name_regex string is rejected before any API request is made,
+        so the user learns of their typo immediately rather than after paginating."""
+        request_mock = mocker.patch.object(invalid_credential_connection._client, "request")
+
+        with pytest.raises(re.error):
+            invalid_credential_connection.list_statements(name_regex="[unterminated")
+
+        request_mock.assert_not_called()
+
+    def test_list_statements_all_three_filters_combined(
+        self,
+        invalid_credential_connection: Connection,
+        statement_response_factory: StatementResponseFactory,
+        mocker,
+    ):
+        """label + compute_pool_id narrow server-side; name_regex filters the result set."""
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "data": [
+                statement_response_factory(name="report-a"),
+                statement_response_factory(name="orders"),
+            ],
+            "metadata": {},
+        }
+
+        request_mock = mocker.patch.object(
+            invalid_credential_connection._client, "request", return_value=mock_response
+        )
+
+        statements = invalid_credential_connection.list_statements(
+            label="daily-report",
+            compute_pool_id="lfcp-xyz",
+            name_regex=r"report",
+        )
+
+        request_mock.assert_called_once_with(
+            "GET",
+            "/statements",
+            params={
+                "page_size": 100,
+                "label_selector": "user.confluent.io/daily-report=true",
+                "spec.compute_pool_id": "lfcp-xyz",
+            },
+        )
+        assert [s.name for s in statements] == ["report-a"]
 
 
 @pytest.mark.unit

--- a/tests/unit/test_connection_unit.py
+++ b/tests/unit/test_connection_unit.py
@@ -195,6 +195,15 @@ class TestGetNextPageToken:
         """Test that _get_next_page_token correctly extracts the page token from a URL."""
         assert invalid_credential_connection._get_next_page_token(url) == expected
 
+    def test_get_next_page_token_empty_string_returns_none(
+        self, invalid_credential_connection: Connection
+    ):
+        """An empty page_token (`?page_token=`) must read as None, not "". list_statements'
+        pagination loop terminates on `next_page_token is not None`; an empty string would keep
+        that guard True while `if next_page_token:` never sets the token, spinning forever."""
+        url = "https://api.confluent.cloud/statements?label_selector=foo&page_token="
+        assert invalid_credential_connection._get_next_page_token(url) is None
+
 
 @pytest.mark.unit
 class TestDeprecatedDbnameParameter:


### PR DESCRIPTION
## list_statements filtering

`Connection.list_statements()` previously _required_ a `label` and could filter by nothing
else. It now supports listing all statements and two additional, combinable filters:

- **List all statements** — `label` is now optional. With no filters supplied,
  `list_statements()` returns every statement in the environment. (#82)
- **Filter by compute pool** — optional `compute_pool_id` kwarg, applied server-side via the
  `spec.compute_pool_id` query parameter, alongside the existing `label_selector`. (#83)
- **Filter by statement name** — optional `name_contains` kwarg (a `str`), applied server-side
  via the `statement_name_search_query` query parameter. The server matches statement names
  containing the given substring, **case-sensitively** (no regex / anchoring). That parameter is
  only honored when `time_ordered=true` is also sent, so `list_statements()` adds it
  automatically whenever `name_contains` is supplied. (#84 — the issue asked for client-side
  regex, but the server-side search query supersedes it: the same user-facing need, name
  filtering, is met without fetching every statement just to discard most of them.)

All three filters AND together and are all applied server-side via query parameters
(`label_selector` + `spec.compute_pool_id` + `statement_name_search_query`), so the result set
is narrowed before it crosses the wire and before pagination. The change is backward compatible
— every parameter is keyword-only and existing `label=` callers are unaffected. A live
integration test (`test_cursor_execute_and_find_with_name_contains`) proves the search-query
parameter substring-matches end-to-end against the real API, and pins its case-sensitivity —
which doubles as a regression guard on the required `time_ordered=true`, since dropping it would
make the server ignore the search term and return everything.

## Docs reconciliation

- ARCHITECTURE.md described statements as **compute-pool scoped** in two places, both wrong:
  - "Statement Persistence and Recovery" claimed statements "can only be found, monitored, and
    recovered within the same compute pool." The list endpoint is keyed on `environments/{env}`
    with the compute pool only ever an optional query filter, so visibility is environment-wide.
    Corrected to say statements are scoped to the **environment** and recoverable from any
    connection to it.
  - "Name Uniqueness" claimed statement names are unique *per compute pool*, with a worked
    example asserting the same name works in two different pools. Names are actually unique
    **per environment**; that example would in fact fail. Rewrote the prose and flipped the
    example to show the cross-pool collision erroring out.
- Both ARCHITECTURE.md and DBAPI_EXTENSIONS.md framed `list_statements()` as "find statements
  **by label**" and predated the new filters. Updated their "Finding…" sections to document that
  `label` is optional (no args → every statement in the environment) and that `compute_pool_id`
  and `name_contains` are also available, combining with AND semantics.

## Relationships

- Closes #82
- Closes #83
- Closes #84
