### PR TITLE
Stop a statement without deleting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this dbapi driver will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- New `Connection.stop_statement(statement, *, wait_for_stopped=True, timeout=300)` method to stop a running statement without deleting it, leaving the statement resource around for inspection (unlike `delete_statement()`, which also destroys it). Accepts a statement name or a `Statement` object. By default it blocks until the statement reaches `STOPPED`; pass `wait_for_stopped=False` to return as soon as the stop is accepted. A matching `Cursor.stop_statement()` stops the cursor's current statement. New `Statement.is_stopped`, `Statement.is_stopping`, and `Statement.stop_requested` properties expose the relevant state. (#61)
+
 ## 0.3.1, 2026-05-21
 
 ### Added

--- a/DBAPI_EXTENSIONS.md
+++ b/DBAPI_EXTENSIONS.md
@@ -35,7 +35,7 @@ For comprehensive details on streaming queries, polling patterns, and changelog 
 
 - [Result Format Extensions](#result-format-extensions) - Dictionary rows, custom types
 - [Streaming Query Support](#streaming-query-support) - Comprehensive streaming guide
-- [Statement Lifecycle Management](#statement-lifecycle-management) - DDL, naming, deletion
+- [Statement Lifecycle Management](#statement-lifecycle-management) - DDL, naming, stopping, deletion
 - [Introspection and Metadata](#introspection-and-metadata) - Properties for query state
 - [Performance Monitoring](#performance-monitoring) - Fetch metrics
 - [Type System Extensions](#type-system-extensions) - Flink type support
@@ -493,6 +493,46 @@ except StatementNotFoundError as e:
 except OperationalError as e:
     print(f"Other error: {e}")
 ```
+
+**`stop_statement()` - Halt a statement without deleting it**
+
+Stops a running statement (for example, a long-lived streaming query) while keeping the
+statement resource around for inspection — unlike `delete_statement()`, which stops *and*
+destroys the statement and its results. The stop is issued as a JSON Patch flipping
+`spec.stopped` to `true`; the statement then transitions through `STOPPING` to the terminal
+`STOPPED` phase.
+
+```python
+# Stop from connection (by name or Statement object), blocking until STOPPED (the default)
+stopped = connection.stop_statement("active-users-query")
+print(stopped.is_stopped)  # True
+
+# Non-blocking: return as soon as the stop is accepted
+stmt = connection.stop_statement(statement_obj, wait_for_stopped=False)
+print(stmt.stop_requested)  # True (the stop was accepted)
+# Note: stmt.phase may still be RUNNING at this instant -- the server transitions the phase
+# to STOPPED asynchronously. Poll get_statement() if you need to observe STOPPED:
+while not connection.get_statement(stmt).is_stopped:
+    time.sleep(0.5)
+
+# Bound the blocking wait (seconds); raises OperationalError on timeout
+stopped = connection.stop_statement("active-users-query", timeout=60)
+
+# Stop from cursor (current statement); updates the cursor's tracked statement
+stopped = cursor.stop_statement()
+```
+
+**Behavior notes:**
+
+- Accepts a statement name (string) or a `Statement` object. A `Statement` already in a terminal
+  phase (`STOPPED`/`COMPLETED`/`FAILED`/`DELETED`) is returned unchanged without an API call.
+- `wait_for_stopped=True` (default) blocks until the statement reaches `STOPPED`, so the caller
+  knows the stop took effect. `wait_for_stopped=False` returns once the stop is accepted —
+  confirm acceptance via `Statement.stop_requested` rather than the phase.
+- Raises `StatementNotFoundError` if the statement does not exist, or `OperationalError` on other
+  API errors, on timeout, or if the statement transitions to `FAILED` while stopping.
+- `cursor.stop_statement()` raises `InterfaceError` when the cursor has no executed statement to
+  stop (it is not a silent no-op like `cursor.delete_statement()`).
 
 **`delete_statement()` - Stop and remove a statement**
 

--- a/DBAPI_EXTENSIONS.md
+++ b/DBAPI_EXTENSIONS.md
@@ -526,9 +526,10 @@ stopped = cursor.stop_statement()
 
 - Accepts a statement name (string) or a `Statement` object. A `Statement` already in a terminal
   phase (`STOPPED`/`COMPLETED`/`FAILED`/`DELETED`) is returned unchanged without an API call.
-- `wait_for_stopped=True` (default) blocks until the statement reaches `STOPPED`, so the caller
-  knows the stop took effect. `wait_for_stopped=False` returns once the stop is accepted —
-  confirm acceptance via `Statement.stop_requested` rather than the phase.
+- `wait_for_stopped=True` (default) blocks until the statement reaches a terminal phase —
+  normally `STOPPED`, but `COMPLETED` if a bounded query finished before the stop landed — so the
+  caller knows the statement is no longer running. `wait_for_stopped=False` returns once the stop
+  is accepted — confirm acceptance via `Statement.stop_requested` rather than the phase.
 - Raises `StatementNotFoundError` if the statement does not exist, or `OperationalError` on other
   API errors, on timeout, or if the statement transitions to `FAILED` while stopping.
 - `cursor.stop_statement()` raises `InterfaceError` when the cursor has no executed statement to

--- a/src/confluent_sql/connection.py
+++ b/src/confluent_sql/connection.py
@@ -848,15 +848,16 @@ class Connection:
                 already in a terminal phase (STOPPED/COMPLETED/FAILED/DELETED) is returned
                 unchanged without contacting the server.
             wait_for_stopped: If True (default), block and refresh-loop until the statement reaches
-                STOPPED before returning. If False, return as soon as the stop is accepted; the
-                returned statement's stop_requested is true even though its phase may still be
-                RUNNING.
-            timeout: Maximum seconds to wait for STOPPED when wait_for_stopped is True.
+                a terminal phase before returning -- normally STOPPED, but COMPLETED if a bounded
+                query happened to finish before the stop landed. If False, return as soon as the
+                stop is accepted; the returned statement's stop_requested is true even though its
+                phase may still be RUNNING.
+            timeout: Maximum seconds to wait for a terminal phase when wait_for_stopped is True.
 
         Returns:
-            A Statement object reflecting the server's response: phase STOPPED when blocking,
-            otherwise the just-accepted statement (stop_requested true, phase possibly still
-            RUNNING).
+            A Statement object reflecting the server's response: a terminal phase (normally
+            STOPPED, possibly COMPLETED) when blocking, otherwise the just-accepted statement
+            (stop_requested true, phase possibly still RUNNING).
 
         Raises:
             TypeError: If statement is neither a string nor a Statement object.

--- a/src/confluent_sql/connection.py
+++ b/src/confluent_sql/connection.py
@@ -9,8 +9,6 @@ from __future__ import annotations
 
 import json
 import logging
-import random
-import time
 import uuid
 import warnings
 from collections import namedtuple
@@ -30,6 +28,7 @@ from .exceptions import (
     StatementNotFoundError,
 )
 from .execution_mode import ExecutionMode
+from .polling import sleep_with_backoff
 from .statement import LABEL_PREFIX as STATEMENT_LABEL_PREFIX
 from .statement import ChangelogRow, Statement
 from .types import PropertiesDict, RowPythonTypes
@@ -925,27 +924,23 @@ class Connection:
             OperationalError: If the statement transitions to FAILED, or if STOPPED is not reached
                 within the timeout.
         """
-        start_time = time.monotonic()
-        current_delay = 1.0
-        max_delay = 30.0
-
-        while True:
-            if statement.is_failed:
+        def raise_if_failed(candidate: Statement) -> None:
+            if candidate.is_failed:
                 raise OperationalError(
-                    f"Statement '{statement.name}' transitioned to FAILED while stopping: "
-                    f"{statement.status.get('detail', '')}"
+                    f"Statement '{candidate.name}' transitioned to FAILED while stopping: "
+                    f"{candidate.status.get('detail', '')}"
                 )
+
+        # Evaluate the state we already hold first -- an already-terminal statement needs no fetch.
+        raise_if_failed(statement)
+        if statement.phase.is_terminal:
+            return statement
+
+        for _ in sleep_with_backoff(timeout):
+            statement = self.get_statement(statement.name)
+            raise_if_failed(statement)
             if statement.phase.is_terminal:
                 return statement
-
-            if time.monotonic() - start_time >= timeout:
-                break
-
-            jitter = random.uniform(0.75, 1.25)
-            time.sleep(current_delay * jitter)
-            current_delay = min(current_delay * 1.5, max_delay)
-
-            statement = self.get_statement(statement.name)
 
         raise OperationalError(
             f"Statement '{statement.name}' did not reach STOPPED within {timeout} seconds"

--- a/src/confluent_sql/connection.py
+++ b/src/confluent_sql/connection.py
@@ -7,7 +7,10 @@ connections to Confluent SQL services.
 
 from __future__ import annotations
 
+import json
 import logging
+import random
+import time
 import uuid
 import warnings
 from collections import namedtuple
@@ -823,6 +826,130 @@ class Connection:
             # Mark the Statement object as deleted for if the caller still is interested in its
             # reference.
             statement.set_deleted()
+
+    def stop_statement(
+        self,
+        statement: str | Statement,
+        *,
+        wait_for_stopped: bool = True,
+        timeout: int = 300,
+    ) -> Statement:
+        """
+        Stop a statement without deleting it, leaving the statement resource around for inspection.
+
+        Unlike delete_statement(), which stops *and* destroys the statement and its results, this
+        halts a running statement (e.g. a long-lived streaming query) while keeping it queryable
+        via get_statement(). The stop is issued as an RFC 6902 JSON Patch flipping spec.stopped to
+        true. The server accepts the stop immediately (spec.stopped becomes true) but transitions
+        the phase through STOPPING to STOPPED asynchronously -- the PATCH response may still report
+        phase RUNNING.
+
+        Args:
+            statement: The name of the statement to stop, or a Statement object. A Statement
+                already in a terminal phase (STOPPED/COMPLETED/FAILED/DELETED) is returned
+                unchanged without contacting the server.
+            wait_for_stopped: If True (default), block and refresh-loop until the statement reaches
+                STOPPED before returning. If False, return as soon as the stop is accepted; the
+                returned statement's stop_requested is true even though its phase may still be
+                RUNNING.
+            timeout: Maximum seconds to wait for STOPPED when wait_for_stopped is True.
+
+        Returns:
+            A Statement object reflecting the server's response: phase STOPPED when blocking,
+            otherwise the just-accepted statement (stop_requested true, phase possibly still
+            RUNNING).
+
+        Raises:
+            TypeError: If statement is neither a string nor a Statement object.
+            StatementNotFoundError: If the statement does not exist (HTTP 404).
+            OperationalError: On other API errors, on timeout, or if the statement transitions to
+                FAILED while waiting.
+        """
+        if isinstance(statement, Statement):
+            if statement.phase.is_terminal:
+                logger.info(
+                    f"Statement {statement.name} is already in terminal phase "
+                    f"{statement.phase.value}, nothing to stop"
+                )
+                return statement
+            statement_name = statement.name
+        else:
+            if not isinstance(statement, str):
+                raise TypeError(
+                    "Statement to stop must be specified by name or Statement object, "
+                    f"got {type(statement)}"
+                )
+            statement_name = statement
+
+        logger.info(f"Stopping statement {statement_name}")
+        patch_ops = [{"op": "replace", "path": "/spec/stopped", "value": True}]
+        response = self._request(
+            f"/statements/{statement_name}",
+            method="PATCH",
+            content=json.dumps(patch_ops),
+            headers={"Content-Type": "application/json-patch+json"},
+            raise_for_status=False,
+        )
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise StatementNotFoundError(
+                    f"Statement '{statement_name}' not found while stopping",
+                    statement_name=statement_name,
+                ) from e
+            raise OperationalError(
+                "Error stopping statement", http_status_code=e.response.status_code
+            ) from e
+
+        pending_stopped_statement = Statement.from_response(self, response.json())
+
+        if wait_for_stopped:
+            return self._wait_for_statement_stopped(pending_stopped_statement, timeout)
+        return pending_stopped_statement
+
+    def _wait_for_statement_stopped(self, statement: Statement, timeout: int) -> Statement:
+        """
+        Refresh-loop until the given statement reaches STOPPED (or another terminal phase).
+
+        The passed-in statement -- typically the PATCH response that accepted the stop -- is
+        evaluated before any re-fetch. The stop transitions the phase server-side asynchronously,
+        so a GET issued immediately would almost certainly report the same non-terminal phase we
+        already hold; we therefore sleep *first* and only fetch once wall-clock time has passed and
+        the server state can actually have advanced. Uses exponential backoff with jitter to avoid
+        hammering the server. A statement that ends in any terminal phase other than FAILED (e.g. a
+        bounded query that COMPLETED before the stop landed) is returned, since the caller's intent
+        -- the statement is no longer running -- is satisfied.
+
+        Raises:
+            OperationalError: If the statement transitions to FAILED, or if STOPPED is not reached
+                within the timeout.
+        """
+        start_time = time.monotonic()
+        current_delay = 1.0
+        max_delay = 30.0
+
+        while True:
+            if statement.is_failed:
+                raise OperationalError(
+                    f"Statement '{statement.name}' transitioned to FAILED while stopping: "
+                    f"{statement.status.get('detail', '')}"
+                )
+            if statement.phase.is_terminal:
+                return statement
+
+            if time.monotonic() - start_time >= timeout:
+                break
+
+            jitter = random.uniform(0.75, 1.25)
+            time.sleep(current_delay * jitter)
+            current_delay = min(current_delay * 1.5, max_delay)
+
+            statement = self.get_statement(statement.name)
+
+        raise OperationalError(
+            f"Statement '{statement.name}' did not reach STOPPED within {timeout} seconds"
+        )
 
     @property
     def is_closed(self) -> bool:

--- a/src/confluent_sql/cursor.py
+++ b/src/confluent_sql/cursor.py
@@ -472,6 +472,37 @@ class Cursor:
         self._connection.delete_statement(self._statement.name)
         self._statement.set_deleted()
 
+    def stop_statement(self, *, wait_for_stopped: bool = True, timeout: int = 300) -> Statement:
+        """
+        Stop this cursor's statement without deleting it, keeping it around for inspection.
+
+        Delegates to Connection.stop_statement and reassigns the cursor's tracked statement to the
+        returned (stopped) Statement. Unlike delete_statement(), stopping with no active statement
+        is an error -- there is no statement to stop and no sensible Statement to return.
+
+        Args:
+            wait_for_stopped: If True (default), block until the statement reaches STOPPED.
+            timeout: Maximum seconds to wait for STOPPED when wait_for_stopped is True.
+
+        Returns:
+            The updated Statement (STOPPED when blocking, otherwise the just-accepted statement
+            with stop_requested true and phase possibly still RUNNING).
+
+        Raises:
+            InterfaceError: If the cursor is closed or no statement has been executed.
+            StatementNotFoundError: If the statement no longer exists.
+            OperationalError: On other API errors, on timeout, or if the statement FAILED.
+        """
+        self._raise_if_closed()
+
+        if self._statement is None:
+            raise InterfaceError("No active statement to stop")
+
+        self._statement = self._connection.stop_statement(
+            self._statement.name, wait_for_stopped=wait_for_stopped, timeout=timeout
+        )
+        return self._statement
+
     @property
     def is_closed(self) -> bool:
         """

--- a/src/confluent_sql/cursor.py
+++ b/src/confluent_sql/cursor.py
@@ -477,16 +477,19 @@ class Cursor:
         Stop this cursor's statement without deleting it, keeping it around for inspection.
 
         Delegates to Connection.stop_statement and reassigns the cursor's tracked statement to the
-        returned (stopped) Statement. Unlike delete_statement(), stopping with no active statement
+        returned Statement. Unlike delete_statement(), stopping with no active statement
         is an error -- there is no statement to stop and no sensible Statement to return.
 
         Args:
-            wait_for_stopped: If True (default), block until the statement reaches STOPPED.
-            timeout: Maximum seconds to wait for STOPPED when wait_for_stopped is True.
+            wait_for_stopped: If True (default), block until the statement reaches a terminal phase
+                -- normally STOPPED, but COMPLETED if a bounded query finished before the stop
+                landed.
+            timeout: Maximum seconds to wait for a terminal phase when wait_for_stopped is True.
 
         Returns:
-            The updated Statement (STOPPED when blocking, otherwise the just-accepted statement
-            with stop_requested true and phase possibly still RUNNING).
+            The updated Statement: a terminal phase (normally STOPPED, possibly COMPLETED) when
+            blocking, otherwise the just-accepted statement with stop_requested true and phase
+            possibly still RUNNING.
 
         Raises:
             InterfaceError: If the cursor is closed or no statement has been executed.

--- a/src/confluent_sql/cursor.py
+++ b/src/confluent_sql/cursor.py
@@ -8,8 +8,6 @@ retrieving results from Confluent SQL services.
 from __future__ import annotations
 
 import logging
-import random
-import time
 import warnings
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, TypeAlias
@@ -22,6 +20,7 @@ from .exceptions import (
     ProgrammingError,
 )
 from .execution_mode import ExecutionMode
+from .polling import sleep_with_backoff
 from .result_readers import (
     AppendOnlyResultReader,
     ChangelogEventReader,
@@ -687,51 +686,56 @@ class Cursor:
                 "Calling _wait_for_statement_ready but _statement is None, this is probably a bug"
             )  # pragma: no cover
 
-        start_time = time.monotonic()
-        base_delay = 1.0  # Start with 1 second
-        max_delay = 30.0  # Maximum delay between polls
-        current_delay = base_delay
-
-        while time.monotonic() - start_time < timeout:
-            logger.info(f"Checking statement '{self._statement.name}' status...")
-
-            response = self._connection._get_statement(self._statement.name)
-
-            self._statement = statement = Statement.from_response(self._connection, response)
-
-            self._raise_if_statement_is_broken(statement)
-
-            # If we can fetch results based on execution mode and statement state,
-            # create the result reader and exit the polling loop.
-            if statement.can_fetch_results(self._execution_mode):
-                if statement.is_append_only:
-                    # Create result reader for append-only statements, will
-                    # return row tuples or dicts depending on self._results_as_dicts.
-                    self._result_reader = AppendOnlyResultReader(
-                        self._connection,
-                        self._statement,
-                        self._execution_mode,
-                        as_dict=self._results_as_dicts,
-                    )
-                else:
-                    # Use a ChangelogEventReader that will return pairs of the changelog
-                    # operation and the type-promoted row data as a dict or tuple depending
-                    # on self._results_as_dicts.
-                    self._result_reader = ChangelogEventReader(
-                        self._connection,
-                        self._statement,
-                        self._execution_mode,
-                        as_dict=self._results_as_dicts,
-                    )
+        # First attempt immediately, then back off between subsequent polls.
+        if self._poll_ready_once():
+            return
+        for _ in sleep_with_backoff(timeout):
+            if self._poll_ready_once():
                 return
 
-            # Otherwise, exponential backoff with jitter to prevent thundering herd
-            jitter = random.uniform(0.75, 1.25)  # ±25% randomness
-            actual_delay = current_delay * jitter
-            time.sleep(actual_delay)
-            current_delay = min(current_delay * 1.5, max_delay)
-
         raise OperationalError(f"Statement submission timed out after {timeout} seconds")
+
+    def _poll_ready_once(self) -> bool:
+        """Refresh self._statement from the server once; return True if results are now fetchable.
+
+        Reassigns self._statement with the latest server state, raises if the statement is broken
+        (failed/degraded/pool-exhausted), and on readiness installs the appropriate result reader
+        before returning True. Returns False if the statement is not yet ready to fetch from.
+        """
+        if self._statement is None:
+            raise InterfaceError(
+                "Calling _poll_ready_once but _statement is None, this is probably a bug"
+            )  # pragma: no cover
+
+        logger.info(f"Checking statement '{self._statement.name}' status...")
+
+        response = self._connection._get_statement(self._statement.name)
+        self._statement = statement = Statement.from_response(self._connection, response)
+
+        self._raise_if_statement_is_broken(statement)
+
+        if not statement.can_fetch_results(self._execution_mode):
+            return False
+
+        if statement.is_append_only:
+            # Append-only statements return row tuples or dicts depending on
+            # self._results_as_dicts.
+            self._result_reader = AppendOnlyResultReader(
+                self._connection,
+                statement,
+                self._execution_mode,
+                as_dict=self._results_as_dicts,
+            )
+        else:
+            # Non-append-only statements return pairs of the changelog operation and the
+            # type-promoted row data as a dict or tuple depending on self._results_as_dicts.
+            self._result_reader = ChangelogEventReader(
+                self._connection,
+                statement,
+                self._execution_mode,
+                as_dict=self._results_as_dicts,
+            )
+        return True
 
     def _raise_if_statement_is_broken(self, statement: Statement) -> None:
         """Raise an exception if the statement is in a failed, degraded, or pool-exhausted state.

--- a/src/confluent_sql/cursor.py
+++ b/src/confluent_sql/cursor.py
@@ -716,19 +716,19 @@ class Cursor:
         logger.info(f"Checking statement '{self._statement.name}' status...")
 
         response = self._connection._get_statement(self._statement.name)
-        self._statement = statement = Statement.from_response(self._connection, response)
+        self._statement = Statement.from_response(self._connection, response)
 
-        self._raise_if_statement_is_broken(statement)
+        self._raise_if_statement_is_broken()
 
-        if not statement.can_fetch_results(self._execution_mode):
+        if not self._statement.can_fetch_results(self._execution_mode):
             return False
 
-        if statement.is_append_only:
+        if self._statement.is_append_only:
             # Append-only statements return row tuples or dicts depending on
             # self._results_as_dicts.
             self._result_reader = AppendOnlyResultReader(
                 self._connection,
-                statement,
+                self._statement,
                 self._execution_mode,
                 as_dict=self._results_as_dicts,
             )
@@ -737,21 +737,27 @@ class Cursor:
             # type-promoted row data as a dict or tuple depending on self._results_as_dicts.
             self._result_reader = ChangelogEventReader(
                 self._connection,
-                statement,
+                self._statement,
                 self._execution_mode,
                 as_dict=self._results_as_dicts,
             )
         return True
 
-    def _raise_if_statement_is_broken(self, statement: Statement) -> None:
-        """Raise an exception if the statement is in a failed, degraded, or pool-exhausted state.
+    def _raise_if_statement_is_broken(self) -> None:
+        """Raise an exception if self._statement is in a failed, degraded, or pool-exhausted state.
 
         Raises:
             OperationalError: If the statement is failed or degraded.
             ComputePoolExhaustedError: If the statement is pool-exhausted (a subclass of
                 OperationalError).
         """
+        if self._statement is None:
+            raise InterfaceError(
+                "Calling _raise_if_statement_is_broken but _statement is None, this is probably"
+                " a bug"
+            )  # pragma: no cover
 
+        statement = self._statement
         if statement.is_failed:
             raise OperationalError(
                 f"Statement '{statement.name}' failed: {statement.status.get('detail', '')}"

--- a/src/confluent_sql/cursor.py
+++ b/src/confluent_sql/cursor.py
@@ -8,6 +8,7 @@ retrieving results from Confluent SQL services.
 from __future__ import annotations
 
 import logging
+import time
 import warnings
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, TypeAlias
@@ -686,10 +687,12 @@ class Cursor:
                 "Calling _wait_for_statement_ready but _statement is None, this is probably a bug"
             )  # pragma: no cover
 
-        # First attempt immediately, then back off between subsequent polls.
+        # First attempt immediately, then back off between subsequent polls. The clock starts
+        # before that first poll so its latency counts against the timeout, not on top of it.
+        started_at = time.monotonic()
         if self._poll_ready_once():
             return
-        for _ in sleep_with_backoff(timeout):
+        for _ in sleep_with_backoff(timeout, started_at=started_at):
             if self._poll_ready_once():
                 return
 

--- a/src/confluent_sql/polling.py
+++ b/src/confluent_sql/polling.py
@@ -1,0 +1,38 @@
+"""Shared pacing for server-polling loops.
+
+Centralizes the exponential-backoff-with-jitter policy used when waiting on asynchronous
+statement state transitions, so the timing mechanics (and their tuning) live in one place rather
+than being copied into each poller.
+"""
+
+import random
+import time
+from collections.abc import Iterator
+
+_POLL_BASE_DELAY_SECS = 1.0
+"""Delay before the first retry sleep."""
+
+_POLL_MAX_DELAY_SECS = 30.0
+"""Ceiling on the per-retry sleep, regardless of how long we have been waiting."""
+
+_POLL_DELAY_GROWTH = 1.5
+"""Multiplier applied to the delay after each retry."""
+
+_POLL_JITTER_BAND = (0.75, 1.25)
+"""Multiplicative jitter band (±25%) applied to each sleep to avoid thundering-herd alignment."""
+
+
+def sleep_with_backoff(timeout_secs: float) -> Iterator[None]:
+    """Pace the retries of a polling loop, yielding once per retry until timeout_secs elapses.
+
+    The caller makes its own first (immediate, unpaced) attempt; each yield then sleeps with
+    exponential backoff + jitter and signals "you have waited, try again". The generator stops
+    yielding once timeout_secs has elapsed, at which point the caller is responsible for raising
+    its own timeout error.
+    """
+    start = time.monotonic()
+    delay = _POLL_BASE_DELAY_SECS
+    while time.monotonic() - start < timeout_secs:
+        time.sleep(delay * random.uniform(*_POLL_JITTER_BAND))
+        delay = min(delay * _POLL_DELAY_GROWTH, _POLL_MAX_DELAY_SECS)
+        yield

--- a/src/confluent_sql/polling.py
+++ b/src/confluent_sql/polling.py
@@ -31,14 +31,20 @@ def sleep_with_backoff(timeout_secs: float, *, started_at: float | None = None) 
     its own timeout error.
 
     Each sleep is clamped to both the 30s ceiling (jitter included -- the cap is on the actual
-    sleep, not the pre-jitter base delay) and the remaining budget, so the total wait never
-    exceeds timeout_secs -- the caller's timeout is an upper bound, not an approximate target. The
-    final paced retry therefore lands right at the deadline rather than running a full backoff step
-    past it.
+    sleep, not the pre-jitter base delay) and the remaining budget, so no paced sleep ever extends
+    past the deadline; the final paced sleep lands right at it rather than running a full backoff
+    step over. The elapsed check is measured from the start each iteration, so time the caller
+    spends in the loop body (e.g. a network GET) is charged against the budget too -- slow caller
+    work ends the pacing sooner, it does not stack on top of the sleeps.
+
+    What this does NOT bound is the caller's own in-flight work: a GET that begins just before the
+    deadline still runs to completion, so total wall time can exceed timeout_secs by up to one unit
+    of caller work. The helper paces the sleeping; it cannot interrupt the caller.
 
     started_at lets a caller that did a timed first attempt (e.g. a network poll) fold that elapsed
-    time into the budget: pass the time.monotonic() captured before that attempt so the timeout
-    bounds the whole operation, not just the paced retries. Defaults to the moment pacing begins.
+    time into the budget: pass the time.monotonic() captured before that attempt so it is charged
+    against the timeout rather than the budget starting fresh after it. Defaults to the moment
+    pacing begins.
     """
     start = time.monotonic() if started_at is None else started_at
     delay = _POLL_BASE_DELAY_SECS

--- a/src/confluent_sql/polling.py
+++ b/src/confluent_sql/polling.py
@@ -22,7 +22,7 @@ _POLL_JITTER_BAND = (0.75, 1.25)
 """Multiplicative jitter band (±25%) applied to each sleep to avoid thundering-herd alignment."""
 
 
-def sleep_with_backoff(timeout_secs: float) -> Iterator[None]:
+def sleep_with_backoff(timeout_secs: float, *, started_at: float | None = None) -> Iterator[None]:
     """Pace the retries of a polling loop, yielding once per retry until timeout_secs elapses.
 
     The caller makes its own first (immediate, unpaced) attempt; each yield then sleeps with
@@ -30,16 +30,22 @@ def sleep_with_backoff(timeout_secs: float) -> Iterator[None]:
     yielding once timeout_secs has elapsed, at which point the caller is responsible for raising
     its own timeout error.
 
-    Each sleep is clamped to the remaining budget, so the total wait never exceeds timeout_secs --
-    the caller's timeout is an upper bound, not an approximate target. The final paced retry
-    therefore lands right at the deadline rather than running a full backoff step past it.
+    Each sleep is clamped to both the 30s ceiling (jitter included -- the cap is on the actual
+    sleep, not the pre-jitter base delay) and the remaining budget, so the total wait never
+    exceeds timeout_secs -- the caller's timeout is an upper bound, not an approximate target. The
+    final paced retry therefore lands right at the deadline rather than running a full backoff step
+    past it.
+
+    started_at lets a caller that did a timed first attempt (e.g. a network poll) fold that elapsed
+    time into the budget: pass the time.monotonic() captured before that attempt so the timeout
+    bounds the whole operation, not just the paced retries. Defaults to the moment pacing begins.
     """
-    start = time.monotonic()
+    start = time.monotonic() if started_at is None else started_at
     delay = _POLL_BASE_DELAY_SECS
     while True:
         remaining = timeout_secs - (time.monotonic() - start)
         if remaining <= 0:
             return
-        time.sleep(min(delay * random.uniform(*_POLL_JITTER_BAND), remaining))
+        time.sleep(min(delay * random.uniform(*_POLL_JITTER_BAND), _POLL_MAX_DELAY_SECS, remaining))
         delay = min(delay * _POLL_DELAY_GROWTH, _POLL_MAX_DELAY_SECS)
         yield

--- a/src/confluent_sql/polling.py
+++ b/src/confluent_sql/polling.py
@@ -29,10 +29,17 @@ def sleep_with_backoff(timeout_secs: float) -> Iterator[None]:
     exponential backoff + jitter and signals "you have waited, try again". The generator stops
     yielding once timeout_secs has elapsed, at which point the caller is responsible for raising
     its own timeout error.
+
+    Each sleep is clamped to the remaining budget, so the total wait never exceeds timeout_secs --
+    the caller's timeout is an upper bound, not an approximate target. The final paced retry
+    therefore lands right at the deadline rather than running a full backoff step past it.
     """
     start = time.monotonic()
     delay = _POLL_BASE_DELAY_SECS
-    while time.monotonic() - start < timeout_secs:
-        time.sleep(delay * random.uniform(*_POLL_JITTER_BAND))
+    while True:
+        remaining = timeout_secs - (time.monotonic() - start)
+        if remaining <= 0:
+            return
+        time.sleep(min(delay * random.uniform(*_POLL_JITTER_BAND), remaining))
         delay = min(delay * _POLL_DELAY_GROWTH, _POLL_MAX_DELAY_SECS)
         yield

--- a/src/confluent_sql/statement.py
+++ b/src/confluent_sql/statement.py
@@ -236,6 +236,26 @@ class Statement:
         return self.phase == Phase.RUNNING
 
     @property
+    def is_stopping(self) -> bool:
+        """Is the statement in the process of stopping (transient, settles to STOPPED)?"""
+        return self.phase == Phase.STOPPING
+
+    @property
+    def is_stopped(self) -> bool:
+        """Has the statement been stopped (terminal)?"""
+        return self.phase == Phase.STOPPED
+
+    @property
+    def stop_requested(self) -> bool:
+        """Has a stop been requested for this statement (spec.stopped is true)?
+
+        This flips true as soon as the server accepts a stop request, which can be *before* the
+        phase transitions away from RUNNING -- the phase change to STOPPING/STOPPED happens
+        asynchronously. Useful for confirming a non-blocking stop_statement() call was accepted.
+        """
+        return bool(self.spec.get("stopped", False))
+
+    @property
     def is_deletable(self) -> bool:
         """Check if the statement can be deleted safely."""
         return self.phase in {Phase.COMPLETED, Phase.FAILED, Phase.STOPPED}

--- a/tests/integration/test_connection.py
+++ b/tests/integration/test_connection.py
@@ -13,7 +13,29 @@ import pytest
 import confluent_sql
 from confluent_sql.connection import Connection
 from confluent_sql.exceptions import StatementNotFoundError
+from confluent_sql.execution_mode import ExecutionMode
 from confluent_sql.statement import Statement
+
+
+def _start_running_streaming_statement(connection, table_name, statement_name):
+    """Launch an unbounded streaming SELECT (stays RUNNING) and return the (cursor, statement)."""
+    cursor = connection.cursor(mode=ExecutionMode.STREAMING_QUERY)
+    cursor.execute(f"SELECT * FROM {table_name}", statement_name=statement_name)
+    assert cursor.statement.is_running, (
+        f"Expected streaming statement to be RUNNING, got {cursor.statement.phase.value}"
+    )
+    return cursor, cursor.statement
+
+
+def _poll_until_stopped(connection, statement_name, timeout_seconds=60):
+    """Poll get_statement until the named statement is STOPPED or timeout."""
+    start = time.monotonic()
+    while time.monotonic() - start < timeout_seconds:
+        statement = connection.get_statement(statement_name)
+        if statement.is_stopped:
+            return statement
+        time.sleep(0.5)
+    raise TimeoutError(f"Statement '{statement_name}' not STOPPED after {timeout_seconds}s")
 
 
 def _wait_for_row(cursor, timeout_seconds=5):
@@ -231,4 +253,107 @@ class TestConnection:
             connection.get_statement("non-existent-statement-name")
 
         # Verify exception has statement name
+        assert exc_info.value.statement_name == "non-existent-statement-name"
+
+
+@pytest.mark.integration
+class TestStopStatement:
+    """Integration tests for stop_statement against a real environment."""
+
+    def test_blocking_stop_reaches_stopped_without_deleting(
+        self,
+        table_connection: Connection,
+        test_table_name: str,
+        cleaned_up_statement_name: str,
+    ):
+        """Blocking stop_statement settles the statement to STOPPED and leaves it queryable."""
+        cursor, _ = _start_running_streaming_statement(
+            table_connection, test_table_name, cleaned_up_statement_name
+        )
+        try:
+            stopped = table_connection.stop_statement(
+                cleaned_up_statement_name, wait_for_stopped=True
+            )
+            assert stopped.is_stopped
+
+            # Proof it was stopped, not deleted: it is still retrievable and STOPPED.
+            still_there = table_connection.get_statement(cleaned_up_statement_name)
+            assert still_there.is_stopped
+        finally:
+            cursor.close()
+
+    def test_non_blocking_stop_returns_promptly_then_settles(
+        self,
+        table_connection: Connection,
+        test_table_name: str,
+        cleaned_up_statement_name: str,
+    ):
+        """Non-blocking stop_statement returns promptly with the stop accepted, then settles.
+
+        The PATCH 200 response reflects the stop request (spec.stopped becomes true) but the phase
+        may still be RUNNING at that instant -- the server transitions to STOPPED asynchronously.
+        """
+        cursor, _ = _start_running_streaming_statement(
+            table_connection, test_table_name, cleaned_up_statement_name
+        )
+        try:
+            result = table_connection.stop_statement(
+                cleaned_up_statement_name, wait_for_stopped=False
+            )
+            assert result.stop_requested
+
+            settled = _poll_until_stopped(table_connection, cleaned_up_statement_name)
+            assert settled.is_stopped
+        finally:
+            cursor.close()
+
+    def test_stopping_already_stopped_statement_is_noop(
+        self,
+        table_connection: Connection,
+        test_table_name: str,
+        cleaned_up_statement_name: str,
+    ):
+        """Re-stopping an already-STOPPED statement returns it and does not raise."""
+        cursor, _ = _start_running_streaming_statement(
+            table_connection, test_table_name, cleaned_up_statement_name
+        )
+        try:
+            stopped = table_connection.stop_statement(
+                cleaned_up_statement_name, wait_for_stopped=True
+            )
+            assert stopped.is_stopped
+
+            # Passing the already-terminal Statement back short-circuits with no error.
+            again = table_connection.stop_statement(stopped)
+            assert again.is_stopped
+        finally:
+            cursor.close()
+
+    def test_cursor_stop_statement(
+        self,
+        table_connection: Connection,
+        test_table_name: str,
+        cleaned_up_statement_name: str,
+    ):
+        """cursor.stop_statement stops the cursor's statement and updates its tracked state."""
+        cursor = table_connection.cursor(mode=ExecutionMode.STREAMING_QUERY)
+        try:
+            cursor.execute(
+                f"SELECT * FROM {test_table_name}", statement_name=cleaned_up_statement_name
+            )
+            assert cursor.statement.is_running
+
+            stopped = cursor.stop_statement(wait_for_stopped=True)
+            assert stopped.is_stopped
+            assert cursor.statement.is_stopped
+
+            # Stopped, not deleted: still retrievable.
+            assert table_connection.get_statement(cleaned_up_statement_name).is_stopped
+        finally:
+            cursor.close()
+
+    def test_stop_nonexistent_statement_raises(self, connection: Connection):
+        """Stopping a non-existent statement raises StatementNotFoundError."""
+        with pytest.raises(StatementNotFoundError) as exc_info:
+            connection.stop_statement("non-existent-statement-name", wait_for_stopped=False)
         assert exc_info.value.statement_name == "non-existent-statement-name"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -72,6 +72,7 @@ def statement_response_factory() -> StatementResponseFactory:
         name: str = "dbapi-d4c685ef-befe-4091-9548-05d5ccb52d4a",
         labels: dict[str, str] | None = None,
         stopped: bool = False,
+        scaling_state: str = "OK",
     ) -> dict[str, Any]:
         """Construct a statement v1 as from JSON dictionary."""
 
@@ -117,7 +118,7 @@ def statement_response_factory() -> StatementResponseFactory:
                 "phase": phase,
                 "scaling_status": {
                     "last_updated": "2025-11-07T18:45:05Z",
-                    "scaling_state": "OK",
+                    "scaling_state": scaling_state,
                 },
                 "traits": {
                     "connection_refs": [],

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -8,7 +8,7 @@ from typing import Any, TypeAlias
 
 import pytest
 
-from confluent_sql import Connection
+from confluent_sql import Connection, Cursor
 from confluent_sql.connection import RowTypeRegistry
 from confluent_sql.statement import ChangelogRow, Op, Statement
 
@@ -170,6 +170,28 @@ def statement_factory(
 
 StatementFactory: TypeAlias = Callable[..., Statement]
 """A factory type alias for creating Statement instances."""
+
+CursorWithStatementFactory: TypeAlias = Callable[..., Cursor]
+"""A factory type alias for creating cursors pre-loaded with a tracked statement."""
+
+
+@pytest.fixture()
+def cursor_with_statement_factory(
+    mock_connection_factory: MockConnectionFactory,
+    statement_factory: StatementFactory,
+) -> CursorWithStatementFactory:
+    """Returns a factory that builds a cursor whose tracked statement is set from the given
+    statement_factory kwargs, so a test can declare the statement state under inspection inline
+    and exercise cursor methods (e.g. _raise_if_statement_is_broken) against it.
+    """
+
+    def _factory(**statement_kwargs: Any) -> Cursor:
+        cursor = mock_connection_factory(None, None).cursor()
+        cursor._statement = statement_factory(**statement_kwargs)
+        return cursor
+
+    return _factory
+
 
 GetStatementsResultsValue: TypeAlias = tuple[list[ChangelogRow], str | None]
 """A type alias for the return value of _get_statement_results()."""

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -71,6 +71,7 @@ def statement_response_factory() -> StatementResponseFactory:
         null_schema: bool = False,
         name: str = "dbapi-d4c685ef-befe-4091-9548-05d5ccb52d4a",
         labels: dict[str, str] | None = None,
+        stopped: bool = False,
     ) -> dict[str, Any]:
         """Construct a statement v1 as from JSON dictionary."""
 
@@ -108,7 +109,7 @@ def statement_response_factory() -> StatementResponseFactory:
                     "sql.snapshot.mode": "now",
                 },
                 "statement": sql_statement,
-                "stopped": False,
+                "stopped": stopped,
             },
             "status": {
                 "detail": status_detail,

--- a/tests/unit/test_connection_unit.py
+++ b/tests/unit/test_connection_unit.py
@@ -232,6 +232,27 @@ class TestConnectionStopStatement:
         assert request_mock.call_count == 3
         assert [call.args[0] for call in request_mock.call_args_list] == ["PATCH", "GET", "GET"]
 
+    def test_blocking_returns_on_completed_when_stop_races_a_bounded_query(
+        self,
+        invalid_credential_connection: Connection,
+        statement_response_factory: StatementResponseFactory,
+        mocker,
+    ):
+        """A bounded query that COMPLETES before the stop lands satisfies the stop rather than
+        erroring: the blocking wait returns the COMPLETED statement, not just STOPPED. Guards the
+        documented contract that any non-FAILED terminal phase is an acceptable outcome."""
+        mocker.patch("time.sleep")
+        request_mock = mocker.patch.object(invalid_credential_connection._client, "request")
+        request_mock.side_effect = [
+            _ok_response(statement_response_factory(name="stmt-1", phase="RUNNING")),  # PATCH
+            _ok_response(statement_response_factory(name="stmt-1", phase="COMPLETED")),  # poll
+        ]
+
+        result = invalid_credential_connection.stop_statement("stmt-1", wait_for_stopped=True)
+
+        assert result.phase.value == "COMPLETED"
+        assert result.phase.is_terminal
+
     def test_blocking_returns_without_polling_when_patch_already_terminal(
         self,
         invalid_credential_connection: Connection,

--- a/tests/unit/test_connection_unit.py
+++ b/tests/unit/test_connection_unit.py
@@ -217,7 +217,7 @@ class TestConnectionStopStatement:
         mocker,
     ):
         """wait_for_stopped=True polls get-statement until the phase settles to STOPPED."""
-        mocker.patch("confluent_sql.connection.time.sleep")
+        mocker.patch("time.sleep")
         request_mock = mocker.patch.object(invalid_credential_connection._client, "request")
         request_mock.side_effect = [
             _ok_response(statement_response_factory(name="stmt-1", phase="STOPPING")),  # PATCH
@@ -332,7 +332,7 @@ class TestConnectionStopStatement:
         mocker,
     ):
         """If the statement never reaches STOPPED within the timeout, OperationalError is raised."""
-        mocker.patch("confluent_sql.connection.time.sleep")
+        mocker.patch("time.sleep")
         request_mock = mocker.patch.object(invalid_credential_connection._client, "request")
         request_mock.return_value = _ok_response(
             statement_response_factory(name="stmt-1", phase="STOPPING")
@@ -350,7 +350,7 @@ class TestConnectionStopStatement:
         mocker,
     ):
         """A statement that transitions to FAILED while waiting raises OperationalError."""
-        mocker.patch("confluent_sql.connection.time.sleep")
+        mocker.patch("time.sleep")
         request_mock = mocker.patch.object(invalid_credential_connection._client, "request")
         request_mock.side_effect = [
             _ok_response(statement_response_factory(name="stmt-1", phase="STOPPING")),  # PATCH

--- a/tests/unit/test_connection_unit.py
+++ b/tests/unit/test_connection_unit.py
@@ -1,4 +1,5 @@
 import copy
+import json
 from collections import namedtuple
 from dataclasses import dataclass
 from typing import NamedTuple
@@ -156,6 +157,214 @@ class TestConnectionDeleteStatementErrors:
         with pytest.raises(OperationalError, match="Error deleting statement") as exc_info:
             invalid_credential_connection.delete_statement("statement-with-error")
         assert exc_info.value.http_status_code == 500
+
+
+def _ok_response(statement_json: dict) -> Mock:
+    """A 200 response mock whose .json() returns the given statement dict."""
+    response_mock = Mock()
+    response_mock.status_code = 200
+    response_mock.raise_for_status = Mock()
+    response_mock.json.return_value = statement_json
+    return response_mock
+
+
+def _http_error_response(status_code: int) -> Mock:
+    """A response mock whose raise_for_status() raises an HTTPStatusError of the given code."""
+    response_mock = Mock()
+    response_mock.status_code = status_code
+
+    def _raise():
+        error_response = Mock()
+        error_response.status_code = status_code
+        raise httpx.HTTPStatusError("boom", request=Mock(), response=error_response)
+
+    response_mock.raise_for_status = _raise
+    return response_mock
+
+
+@pytest.mark.unit
+class TestConnectionStopStatement:
+    """Tests for Connection.stop_statement."""
+
+    def test_non_blocking_issues_json_patch_and_returns_stopping(
+        self,
+        invalid_credential_connection: Connection,
+        statement_response_factory: StatementResponseFactory,
+        mocker,
+    ):
+        """wait_for_stopped=False issues a single RFC 6902 PATCH and returns the STOPPING
+        statement without polling."""
+        request_mock = mocker.patch.object(invalid_credential_connection._client, "request")
+        request_mock.return_value = _ok_response(
+            statement_response_factory(name="stmt-1", phase="STOPPING")
+        )
+
+        result = invalid_credential_connection.stop_statement("stmt-1", wait_for_stopped=False)
+
+        assert result.is_stopping
+        request_mock.assert_called_once()
+        args, kwargs = request_mock.call_args
+        assert args == ("PATCH", "/statements/stmt-1")
+        assert kwargs["headers"]["Content-Type"] == "application/json-patch+json"
+        assert json.loads(kwargs["content"]) == [
+            {"op": "replace", "path": "/spec/stopped", "value": True}
+        ]
+
+    def test_blocking_polls_until_stopped(
+        self,
+        invalid_credential_connection: Connection,
+        statement_response_factory: StatementResponseFactory,
+        mocker,
+    ):
+        """wait_for_stopped=True polls get-statement until the phase settles to STOPPED."""
+        mocker.patch("confluent_sql.connection.time.sleep")
+        request_mock = mocker.patch.object(invalid_credential_connection._client, "request")
+        request_mock.side_effect = [
+            _ok_response(statement_response_factory(name="stmt-1", phase="STOPPING")),  # PATCH
+            _ok_response(statement_response_factory(name="stmt-1", phase="STOPPING")),  # poll 1
+            _ok_response(statement_response_factory(name="stmt-1", phase="STOPPED")),  # poll 2
+        ]
+
+        result = invalid_credential_connection.stop_statement("stmt-1", wait_for_stopped=True)
+
+        assert result.is_stopped
+        # One PATCH + two GET polls.
+        assert request_mock.call_count == 3
+        assert [call.args[0] for call in request_mock.call_args_list] == ["PATCH", "GET", "GET"]
+
+    def test_blocking_returns_without_polling_when_patch_already_terminal(
+        self,
+        invalid_credential_connection: Connection,
+        statement_response_factory: StatementResponseFactory,
+        mocker,
+    ):
+        """If the PATCH response is already terminal, the blocking wait returns it directly,
+        without an additional get-statement poll."""
+        request_mock = mocker.patch.object(invalid_credential_connection._client, "request")
+        request_mock.return_value = _ok_response(
+            statement_response_factory(name="stmt-1", phase="STOPPED")
+        )
+
+        result = invalid_credential_connection.stop_statement("stmt-1", wait_for_stopped=True)
+
+        assert result.is_stopped
+        # Just the PATCH -- the PATCH response was already STOPPED, so no GET poll is needed.
+        request_mock.assert_called_once()
+        assert request_mock.call_args.args[0] == "PATCH"
+
+    @pytest.mark.parametrize("by_object", [False, True])
+    def test_accepts_name_or_statement_object(
+        self,
+        invalid_credential_connection: Connection,
+        statement_response_factory: StatementResponseFactory,
+        mocker,
+        by_object: bool,
+    ):
+        """stop_statement accepts either a statement name or a Statement object."""
+        request_mock = mocker.patch.object(invalid_credential_connection._client, "request")
+        request_mock.return_value = _ok_response(
+            statement_response_factory(name="stmt-1", phase="STOPPING")
+        )
+
+        if by_object:
+            running = Statement.from_response(
+                invalid_credential_connection,
+                statement_response_factory(name="stmt-1", phase="RUNNING"),
+            )
+            target = running
+        else:
+            target = "stmt-1"
+
+        result = invalid_credential_connection.stop_statement(target, wait_for_stopped=False)
+
+        assert result.is_stopping
+        assert request_mock.call_args.args == ("PATCH", "/statements/stmt-1")
+
+    def test_already_terminal_statement_short_circuits(
+        self,
+        invalid_credential_connection: Connection,
+        statement_response_factory: StatementResponseFactory,
+        mocker,
+    ):
+        """A passed-in Statement already in a terminal phase returns unchanged with no API call."""
+        request_mock = mocker.patch.object(invalid_credential_connection._client, "request")
+        already_stopped = Statement.from_response(
+            invalid_credential_connection,
+            statement_response_factory(name="stmt-1", phase="STOPPED"),
+        )
+
+        result = invalid_credential_connection.stop_statement(already_stopped)
+
+        assert result is already_stopped
+        request_mock.assert_not_called()
+
+    def test_rejects_bad_type(self, invalid_credential_connection: Connection):
+        """A non-str, non-Statement argument raises TypeError."""
+        with pytest.raises(TypeError, match="name or Statement object"):
+            invalid_credential_connection.stop_statement(42)  # type: ignore[arg-type]
+
+    def test_404_raises_statement_not_found(
+        self, invalid_credential_connection: Connection, mocker
+    ):
+        """A 404 from the PATCH surfaces as StatementNotFoundError naming the statement."""
+        request_mock = mocker.patch.object(invalid_credential_connection._client, "request")
+        request_mock.return_value = _http_error_response(404)
+
+        with pytest.raises(StatementNotFoundError) as exc_info:
+            invalid_credential_connection.stop_statement("ghost", wait_for_stopped=False)
+        assert exc_info.value.statement_name == "ghost"
+
+    def test_other_http_error_raises_operational_error(
+        self, invalid_credential_connection: Connection, mocker
+    ):
+        """A non-404 error from the PATCH surfaces as OperationalError carrying the status code."""
+        request_mock = mocker.patch.object(invalid_credential_connection._client, "request")
+        request_mock.return_value = _http_error_response(500)
+
+        with pytest.raises(OperationalError, match="Error stopping statement") as exc_info:
+            invalid_credential_connection.stop_statement("stmt-1", wait_for_stopped=False)
+        assert exc_info.value.http_status_code == 500
+
+    def test_blocking_timeout_raises(
+        self,
+        invalid_credential_connection: Connection,
+        statement_response_factory: StatementResponseFactory,
+        mocker,
+    ):
+        """If the statement never reaches STOPPED within the timeout, OperationalError is raised."""
+        mocker.patch("confluent_sql.connection.time.sleep")
+        request_mock = mocker.patch.object(invalid_credential_connection._client, "request")
+        request_mock.return_value = _ok_response(
+            statement_response_factory(name="stmt-1", phase="STOPPING")
+        )
+
+        with pytest.raises(OperationalError, match="did not reach STOPPED within"):
+            invalid_credential_connection.stop_statement(
+                "stmt-1", wait_for_stopped=True, timeout=0
+            )
+
+    def test_blocking_failed_raises(
+        self,
+        invalid_credential_connection: Connection,
+        statement_response_factory: StatementResponseFactory,
+        mocker,
+    ):
+        """A statement that transitions to FAILED while waiting raises OperationalError."""
+        mocker.patch("confluent_sql.connection.time.sleep")
+        request_mock = mocker.patch.object(invalid_credential_connection._client, "request")
+        request_mock.side_effect = [
+            _ok_response(statement_response_factory(name="stmt-1", phase="STOPPING")),  # PATCH
+            _ok_response(statement_response_factory(name="stmt-1", phase="FAILED")),  # poll
+        ]
+
+        with pytest.raises(OperationalError, match="stmt-1"):
+            invalid_credential_connection.stop_statement("stmt-1", wait_for_stopped=True)
+
+    def test_closed_connection_raises(self, invalid_credential_connection: Connection):
+        """Stopping via a closed connection raises InterfaceError."""
+        invalid_credential_connection.close()
+        with pytest.raises(InterfaceError, match="Connection is closed"):
+            invalid_credential_connection.stop_statement("stmt-1", wait_for_stopped=False)
 
 
 @pytest.mark.unit

--- a/tests/unit/test_connection_unit.py
+++ b/tests/unit/test_connection_unit.py
@@ -186,22 +186,26 @@ def _http_error_response(status_code: int) -> Mock:
 class TestConnectionStopStatement:
     """Tests for Connection.stop_statement."""
 
-    def test_non_blocking_issues_json_patch_and_returns_stopping(
+    def test_non_blocking_issues_json_patch_and_returns_stop_requested(
         self,
         invalid_credential_connection: Connection,
         statement_response_factory: StatementResponseFactory,
         mocker,
     ):
-        """wait_for_stopped=False issues a single RFC 6902 PATCH and returns the STOPPING
-        statement without polling."""
+        """wait_for_stopped=False issues a single RFC 6902 PATCH and returns without polling. Per
+        the real API the accepted-stop response flips spec.stopped to true while status.phase may
+        still read RUNNING, so the caller's reliable signal is stop_requested, not the phase."""
         request_mock = mocker.patch.object(invalid_credential_connection._client, "request")
         request_mock.return_value = _ok_response(
-            statement_response_factory(name="stmt-1", phase="STOPPING")
+            statement_response_factory(name="stmt-1", phase="RUNNING", stopped=True)
         )
 
         result = invalid_credential_connection.stop_statement("stmt-1", wait_for_stopped=False)
 
-        assert result.is_stopping
+        assert result.stop_requested
+        # The phase has not yet transitioned -- stop_requested, not the phase, proves acceptance.
+        assert result.is_running
+        assert not result.is_stopped
         request_mock.assert_called_once()
         args, kwargs = request_mock.call_args
         assert args == ("PATCH", "/statements/stmt-1")
@@ -219,15 +223,19 @@ class TestConnectionStopStatement:
         """wait_for_stopped=True polls get-statement until the phase settles to STOPPED."""
         mocker.patch("time.sleep")
         request_mock = mocker.patch.object(invalid_credential_connection._client, "request")
+        # Per the real API, every response after the accepted stop carries spec.stopped=true; the
+        # phase trails behind, transitioning STOPPING -> STOPPED asynchronously.
         request_mock.side_effect = [
-            _ok_response(statement_response_factory(name="stmt-1", phase="STOPPING")),  # PATCH
-            _ok_response(statement_response_factory(name="stmt-1", phase="STOPPING")),  # poll 1
-            _ok_response(statement_response_factory(name="stmt-1", phase="STOPPED")),  # poll 2
+            # PATCH, then poll 1, then poll 2.
+            _ok_response(statement_response_factory(name="stmt-1", phase="STOPPING", stopped=True)),
+            _ok_response(statement_response_factory(name="stmt-1", phase="STOPPING", stopped=True)),
+            _ok_response(statement_response_factory(name="stmt-1", phase="STOPPED", stopped=True)),
         ]
 
         result = invalid_credential_connection.stop_statement("stmt-1", wait_for_stopped=True)
 
         assert result.is_stopped
+        assert result.stop_requested
         # One PATCH + two GET polls.
         assert request_mock.call_count == 3
         assert [call.args[0] for call in request_mock.call_args_list] == ["PATCH", "GET", "GET"]
@@ -244,8 +252,11 @@ class TestConnectionStopStatement:
         mocker.patch("time.sleep")
         request_mock = mocker.patch.object(invalid_credential_connection._client, "request")
         request_mock.side_effect = [
-            _ok_response(statement_response_factory(name="stmt-1", phase="RUNNING")),  # PATCH
-            _ok_response(statement_response_factory(name="stmt-1", phase="COMPLETED")),  # poll
+            # PATCH (stop accepted while still RUNNING), then a poll that finds it COMPLETED.
+            _ok_response(statement_response_factory(name="stmt-1", phase="RUNNING", stopped=True)),
+            _ok_response(
+                statement_response_factory(name="stmt-1", phase="COMPLETED", stopped=True)
+            ),
         ]
 
         result = invalid_credential_connection.stop_statement("stmt-1", wait_for_stopped=True)
@@ -263,7 +274,7 @@ class TestConnectionStopStatement:
         without an additional get-statement poll."""
         request_mock = mocker.patch.object(invalid_credential_connection._client, "request")
         request_mock.return_value = _ok_response(
-            statement_response_factory(name="stmt-1", phase="STOPPED")
+            statement_response_factory(name="stmt-1", phase="STOPPED", stopped=True)
         )
 
         result = invalid_credential_connection.stop_statement("stmt-1", wait_for_stopped=True)
@@ -284,7 +295,7 @@ class TestConnectionStopStatement:
         """stop_statement accepts either a statement name or a Statement object."""
         request_mock = mocker.patch.object(invalid_credential_connection._client, "request")
         request_mock.return_value = _ok_response(
-            statement_response_factory(name="stmt-1", phase="STOPPING")
+            statement_response_factory(name="stmt-1", phase="STOPPING", stopped=True)
         )
 
         if by_object:
@@ -311,7 +322,7 @@ class TestConnectionStopStatement:
         request_mock = mocker.patch.object(invalid_credential_connection._client, "request")
         already_stopped = Statement.from_response(
             invalid_credential_connection,
-            statement_response_factory(name="stmt-1", phase="STOPPED"),
+            statement_response_factory(name="stmt-1", phase="STOPPED", stopped=True),
         )
 
         result = invalid_credential_connection.stop_statement(already_stopped)
@@ -356,7 +367,7 @@ class TestConnectionStopStatement:
         mocker.patch("time.sleep")
         request_mock = mocker.patch.object(invalid_credential_connection._client, "request")
         request_mock.return_value = _ok_response(
-            statement_response_factory(name="stmt-1", phase="STOPPING")
+            statement_response_factory(name="stmt-1", phase="STOPPING", stopped=True)
         )
 
         with pytest.raises(OperationalError, match="did not reach STOPPED within"):
@@ -374,8 +385,9 @@ class TestConnectionStopStatement:
         mocker.patch("time.sleep")
         request_mock = mocker.patch.object(invalid_credential_connection._client, "request")
         request_mock.side_effect = [
-            _ok_response(statement_response_factory(name="stmt-1", phase="STOPPING")),  # PATCH
-            _ok_response(statement_response_factory(name="stmt-1", phase="FAILED")),  # poll
+            # PATCH (stop accepted), then a poll that finds it transitioned to FAILED.
+            _ok_response(statement_response_factory(name="stmt-1", phase="STOPPING", stopped=True)),
+            _ok_response(statement_response_factory(name="stmt-1", phase="FAILED", stopped=True)),
         ]
 
         with pytest.raises(OperationalError, match="stmt-1"):

--- a/tests/unit/test_cursor_unit.py
+++ b/tests/unit/test_cursor_unit.py
@@ -1,6 +1,8 @@
 import re
 import types
 import warnings
+from collections.abc import Callable
+from typing import Any
 
 import pytest
 
@@ -15,7 +17,12 @@ from confluent_sql.exceptions import (
 from confluent_sql.execution_mode import ExecutionMode
 from confluent_sql.result_readers import ChangelogEventReader, ChangeloggedRow, FetchMetrics
 from confluent_sql.statement import ChangelogRow, Op, Statement
-from tests.unit.conftest import MockConnectionFactory, ResultRowFactory, StatementResponseFactory
+from tests.unit.conftest import (
+    MockConnectionFactory,
+    ResultRowFactory,
+    StatementFactory,
+    StatementResponseFactory,
+)
 
 
 @pytest.fixture()
@@ -113,12 +120,11 @@ class TestExecute:
         with pytest.raises(OperationalError):
             mock_connection_cursor.execute("SELECT 1 AS col")
 
-        # Verify that _raise_if_statement_is_broken was called
-        raise_if_broken_mock.assert_called_once()
-        # Verify it was called with a Statement object
-        called_statement = raise_if_broken_mock.call_args[0][0]
-        assert isinstance(called_statement, Statement)
-        assert called_statement.phase.name == "FAILED"
+        # Verify that _raise_if_statement_is_broken was called, after the cursor had refreshed
+        # _statement to the FAILED state it inspects.
+        raise_if_broken_mock.assert_called_once_with()
+        assert mock_connection_cursor._statement is not None
+        assert mock_connection_cursor._statement.phase.name == "FAILED"
 
     def test_execute_calls_raise_if_statement_is_broken_for_degraded_statement(
         self,
@@ -145,12 +151,11 @@ class TestExecute:
         with pytest.raises(OperationalError):
             mock_connection_cursor.execute("SELECT 1 AS col")
 
-        # Verify that _raise_if_statement_is_broken was called
-        raise_if_broken_mock.assert_called_once()
-        # Verify it was called with a Statement object
-        called_statement = raise_if_broken_mock.call_args[0][0]
-        assert isinstance(called_statement, Statement)
-        assert called_statement.phase.name == "DEGRADED"
+        # Verify that _raise_if_statement_is_broken was called, after the cursor had refreshed
+        # _statement to the DEGRADED state it inspects.
+        raise_if_broken_mock.assert_called_once_with()
+        assert mock_connection_cursor._statement is not None
+        assert mock_connection_cursor._statement.phase.name == "DEGRADED"
 
     def test_execute_calls_raise_if_statement_is_broken_for_pool_exhausted(
         self,
@@ -160,8 +165,9 @@ class TestExecute:
     ):
         """Prove that _raise_if_statement_is_broken is called for pool-exhausted statements."""
         # Mock the connection's _get_statement to return a pool-exhausted statement.
-        pool_exhausted_dict = statement_response_factory(phase="PENDING")
-        pool_exhausted_dict["status"]["scaling_status"]["scaling_state"] = "POOL_EXHAUSTED"
+        pool_exhausted_dict = statement_response_factory(
+            phase="PENDING", scaling_state="POOL_EXHAUSTED"
+        )
         mock_connection_cursor._connection._get_statement.return_value = (  # type: ignore
             pool_exhausted_dict
         )
@@ -181,13 +187,12 @@ class TestExecute:
         with pytest.raises(ComputePoolExhaustedError):
             mock_connection_cursor.execute("SELECT 1 AS col")
 
-        # Verify that _raise_if_statement_is_broken was called
-        raise_if_broken_mock.assert_called_once()
-        # Verify it was called with a Statement object
-        called_statement = raise_if_broken_mock.call_args[0][0]
-        assert isinstance(called_statement, Statement)
-        assert called_statement.phase.name == "PENDING"
-        assert called_statement.is_pool_exhausted
+        # Verify that _raise_if_statement_is_broken was called, after the cursor had refreshed
+        # _statement to the pool-exhausted state it inspects.
+        raise_if_broken_mock.assert_called_once_with()
+        assert mock_connection_cursor._statement is not None
+        assert mock_connection_cursor._statement.phase.name == "PENDING"
+        assert mock_connection_cursor._statement.is_pool_exhausted
 
     def test_execute_statement_times_out(
         self,
@@ -1406,81 +1411,78 @@ class TestArraysizeProperty:
 class TestRaiseIfStatementIsBroken:
     """Unit tests for Cursor._raise_if_statement_is_broken()."""
 
-    def test_does_nothing_for_healthy_statement(
+    @pytest.fixture
+    def cursor_with_statement_factory(
         self,
         mock_connection_cursor: Cursor,
-        statement_factory,
+        statement_factory: StatementFactory,
+    ) -> Callable[..., Cursor]:
+        """Returns a factory that installs a statement (built from the given statement_factory
+        kwargs) as the cursor's tracked statement and hands the cursor back, so each test can
+        declare the state under inspection inline and then call the no-argument
+        _raise_if_statement_is_broken() against it.
+        """
+
+        def _factory(**statement_kwargs: Any) -> Cursor:
+            mock_connection_cursor._statement = statement_factory(**statement_kwargs)
+            return mock_connection_cursor
+
+        return _factory
+
+    def test_does_nothing_for_healthy_statement(
+        self, cursor_with_statement_factory: Callable[..., Cursor]
     ):
         """Test that no exception is raised for a healthy statement."""
-        # Create a statement that is neither failed, degraded, nor pool-exhausted
-        healthy_statement = statement_factory(phase="RUNNING")
+        cursor = cursor_with_statement_factory(phase="RUNNING")
+        cursor._raise_if_statement_is_broken()
 
-        # Should not raise any exception
-        mock_connection_cursor._raise_if_statement_is_broken(healthy_statement)
-
-    def test_raises_operational_error_for_failed_statement(
+    @pytest.mark.parametrize(
+        ("phase", "status_detail", "expected_match"),
+        [
+            (
+                "FAILED",
+                "Database connection lost",
+                "Statement .* failed: Database connection lost",
+            ),
+            (
+                "DEGRADED",
+                "Memory limit exceeded",
+                "Statement .* is in DEGRADED state: Memory limit exceeded",
+            ),
+        ],
+    )
+    def test_raises_operational_error_for_broken_statement(
         self,
-        mock_connection_cursor: Cursor,
-        statement_factory,
+        cursor_with_statement_factory: Callable[..., Cursor],
+        phase: str,
+        status_detail: str,
+        expected_match: str,
     ):
-        """Test that OperationalError is raised for a failed statement."""
-        failed_statement = statement_factory(
-            phase="FAILED",
-            status_detail="Database connection lost",
-        )
+        """Test that OperationalError surfaces the detail for failed and degraded statements."""
+        cursor = cursor_with_statement_factory(phase=phase, status_detail=status_detail)
 
-        with pytest.raises(
-            OperationalError,
-            match="Statement .* failed: Database connection lost",
-        ):
-            mock_connection_cursor._raise_if_statement_is_broken(failed_statement)
-
-    def test_raises_operational_error_for_degraded_statement(
-        self,
-        mock_connection_cursor: Cursor,
-        statement_factory,
-    ):
-        """Test that OperationalError is raised for a degraded statement."""
-        degraded_statement = statement_factory(
-            phase="DEGRADED",
-            status_detail="Memory limit exceeded",
-        )
-
-        with pytest.raises(
-            OperationalError,
-            match="Statement .* is in DEGRADED state: Memory limit exceeded",
-        ):
-            mock_connection_cursor._raise_if_statement_is_broken(degraded_statement)
+        with pytest.raises(OperationalError, match=expected_match):
+            cursor._raise_if_statement_is_broken()
 
     def test_raises_compute_pool_exhausted_error_and_deletes_statement(
         self,
-        mock_connection_cursor: Cursor,
-        statement_response_factory: StatementResponseFactory,
+        cursor_with_statement_factory: Callable[..., Cursor],
         mocker,
     ):
         """Test that ComputePoolExhaustedError is raised for pool-exhausted statement
         and that the statement is deleted."""
-        # Create a pool-exhausted statement response
-        pool_exhausted_response = statement_response_factory(phase="PENDING")
-        pool_exhausted_response["status"]["scaling_status"]["scaling_state"] = "POOL_EXHAUSTED"
-
-        # Create the statement from response
-        pool_exhausted_statement = Statement.from_response(
-            mock_connection_cursor._connection,
-            pool_exhausted_response,
-        )
-        # Assign the statement to the cursor so delete_statement has a target
-        mock_connection_cursor._statement = pool_exhausted_statement
+        cursor = cursor_with_statement_factory(phase="PENDING", scaling_state="POOL_EXHAUSTED")
+        assert cursor._statement is not None
 
         # Spy on delete_statement to verify it's called
-        delete_spy = mocker.spy(mock_connection_cursor, "delete_statement")
+        delete_spy = mocker.spy(cursor, "delete_statement")
 
         with pytest.raises(ComputePoolExhaustedError) as exc_info:
-            mock_connection_cursor._raise_if_statement_is_broken(pool_exhausted_statement)
+            cursor._raise_if_statement_is_broken()
 
         # Verify the exception properties
         exception = exc_info.value
-        assert exception.statement_name == pool_exhausted_statement.name
+        assert exception.statement_name == cursor._statement.name
         assert exception.statement_deleted is True
         assert "The statement has been deleted." in str(exception)
         assert "Please retry your query." in str(exception)
@@ -1490,37 +1492,28 @@ class TestRaiseIfStatementIsBroken:
 
     def test_logs_error_when_delete_fails_for_pool_exhausted(
         self,
-        mock_connection_cursor: Cursor,
-        statement_response_factory: StatementResponseFactory,
+        cursor_with_statement_factory: Callable[..., Cursor],
         mocker,
         caplog,
     ):
         """Test that an error is logged if deleting a pool-exhausted statement fails."""
-        # Create a pool-exhausted statement response
-        pool_exhausted_response = statement_response_factory(phase="PENDING")
-        pool_exhausted_response["status"]["scaling_status"]["scaling_state"] = "POOL_EXHAUSTED"
-
-        pool_exhausted_statement = Statement.from_response(
-            mock_connection_cursor._connection,
-            pool_exhausted_response,
-        )
-        # Assign the statement to the cursor so delete_statement attempts deletion
-        mock_connection_cursor._statement = pool_exhausted_statement
+        cursor = cursor_with_statement_factory(phase="PENDING", scaling_state="POOL_EXHAUSTED")
+        assert cursor._statement is not None
 
         # Mock delete_statement to raise an exception
         mocker.patch.object(
-            mock_connection_cursor,
+            cursor,
             "delete_statement",
             side_effect=Exception("Network error during delete"),
         )
 
         # The method should still raise ComputePoolExhaustedError even if delete fails
         with pytest.raises(ComputePoolExhaustedError) as exc_info:
-            mock_connection_cursor._raise_if_statement_is_broken(pool_exhausted_statement)
+            cursor._raise_if_statement_is_broken()
 
         # Verify the exception properties when deletion failed
         exception = exc_info.value
-        assert exception.statement_name == pool_exhausted_statement.name
+        assert exception.statement_name == cursor._statement.name
         assert exception.statement_deleted is False
         assert "The statement could not be deleted and may need manual cleanup." in str(exception)
         assert "Please retry your query." in str(exception)
@@ -1529,33 +1522,23 @@ class TestRaiseIfStatementIsBroken:
         assert "Error deleting pool-exhausted statement" in caplog.text
         assert "Network error during delete" in caplog.text
 
-    def test_pool_exhausted_check_requires_pending_phase_and_pool_exhausted_state(
+    @pytest.mark.parametrize(
+        ("phase", "scaling_state"),
+        [
+            ("RUNNING", "POOL_EXHAUSTED"),  # POOL_EXHAUSTED only counts during PENDING
+            ("PENDING", "OK"),  # PENDING alone, without POOL_EXHAUSTED, is not exhaustion
+        ],
+    )
+    def test_pool_exhausted_requires_pending_phase_and_pool_exhausted_state(
         self,
-        mock_connection_cursor: Cursor,
-        statement_response_factory: StatementResponseFactory,
+        cursor_with_statement_factory: Callable[..., Cursor],
+        phase: str,
+        scaling_state: str,
     ):
         """Test that pool exhaustion only triggers when both conditions are met:
-        phase=PENDING AND scaling_state=POOL_EXHAUSTED."""
-
-        # Test 1: RUNNING phase with POOL_EXHAUSTED scaling_state should not trigger
-        running_response = statement_response_factory(phase="RUNNING")
-        running_response["status"]["scaling_status"]["scaling_state"] = "POOL_EXHAUSTED"
-        running_statement = Statement.from_response(
-            mock_connection_cursor._connection,
-            running_response,
-        )
-        # Should not raise (statement is not pool-exhausted because it's RUNNING)
-        mock_connection_cursor._raise_if_statement_is_broken(running_statement)
-
-        # Test 2: PENDING phase with OK scaling_state should not trigger
-        pending_ok_response = statement_response_factory(phase="PENDING")
-        pending_ok_response["status"]["scaling_status"]["scaling_state"] = "OK"
-        pending_ok_statement = Statement.from_response(
-            mock_connection_cursor._connection,
-            pending_ok_response,
-        )
-        # Should not raise (statement is PENDING but not pool-exhausted)
-        mock_connection_cursor._raise_if_statement_is_broken(pending_ok_statement)
+        phase=PENDING AND scaling_state=POOL_EXHAUSTED. Either condition alone must not raise."""
+        cursor = cursor_with_statement_factory(phase=phase, scaling_state=scaling_state)
+        cursor._raise_if_statement_is_broken()
 
     def test_compute_pool_exhausted_error_properties(self):
         """Test that ComputePoolExhaustedError correctly exposes statement properties."""

--- a/tests/unit/test_cursor_unit.py
+++ b/tests/unit/test_cursor_unit.py
@@ -1,8 +1,6 @@
 import re
 import types
 import warnings
-from collections.abc import Callable
-from typing import Any
 
 import pytest
 
@@ -18,9 +16,9 @@ from confluent_sql.execution_mode import ExecutionMode
 from confluent_sql.result_readers import ChangelogEventReader, ChangeloggedRow, FetchMetrics
 from confluent_sql.statement import ChangelogRow, Op, Statement
 from tests.unit.conftest import (
+    CursorWithStatementFactory,
     MockConnectionFactory,
     ResultRowFactory,
-    StatementFactory,
     StatementResponseFactory,
 )
 
@@ -1411,26 +1409,8 @@ class TestArraysizeProperty:
 class TestRaiseIfStatementIsBroken:
     """Unit tests for Cursor._raise_if_statement_is_broken()."""
 
-    @pytest.fixture
-    def cursor_with_statement_factory(
-        self,
-        mock_connection_cursor: Cursor,
-        statement_factory: StatementFactory,
-    ) -> Callable[..., Cursor]:
-        """Returns a factory that installs a statement (built from the given statement_factory
-        kwargs) as the cursor's tracked statement and hands the cursor back, so each test can
-        declare the state under inspection inline and then call the no-argument
-        _raise_if_statement_is_broken() against it.
-        """
-
-        def _factory(**statement_kwargs: Any) -> Cursor:
-            mock_connection_cursor._statement = statement_factory(**statement_kwargs)
-            return mock_connection_cursor
-
-        return _factory
-
     def test_does_nothing_for_healthy_statement(
-        self, cursor_with_statement_factory: Callable[..., Cursor]
+        self, cursor_with_statement_factory: CursorWithStatementFactory
     ):
         """Test that no exception is raised for a healthy statement."""
         cursor = cursor_with_statement_factory(phase="RUNNING")
@@ -1453,7 +1433,7 @@ class TestRaiseIfStatementIsBroken:
     )
     def test_raises_operational_error_for_broken_statement(
         self,
-        cursor_with_statement_factory: Callable[..., Cursor],
+        cursor_with_statement_factory: CursorWithStatementFactory,
         phase: str,
         status_detail: str,
         expected_match: str,
@@ -1466,7 +1446,7 @@ class TestRaiseIfStatementIsBroken:
 
     def test_raises_compute_pool_exhausted_error_and_deletes_statement(
         self,
-        cursor_with_statement_factory: Callable[..., Cursor],
+        cursor_with_statement_factory: CursorWithStatementFactory,
         mocker,
     ):
         """Test that ComputePoolExhaustedError is raised for pool-exhausted statement
@@ -1492,7 +1472,7 @@ class TestRaiseIfStatementIsBroken:
 
     def test_logs_error_when_delete_fails_for_pool_exhausted(
         self,
-        cursor_with_statement_factory: Callable[..., Cursor],
+        cursor_with_statement_factory: CursorWithStatementFactory,
         mocker,
         caplog,
     ):
@@ -1531,7 +1511,7 @@ class TestRaiseIfStatementIsBroken:
     )
     def test_pool_exhausted_requires_pending_phase_and_pool_exhausted_state(
         self,
-        cursor_with_statement_factory: Callable[..., Cursor],
+        cursor_with_statement_factory: CursorWithStatementFactory,
         phase: str,
         scaling_state: str,
     ):

--- a/tests/unit/test_cursor_unit.py
+++ b/tests/unit/test_cursor_unit.py
@@ -1852,31 +1852,34 @@ class TestComputePoolIdParameter:
 class TestStopStatement:
     """Tests for Cursor.stop_statement."""
 
+    @pytest.mark.parametrize("returned_phase", ["STOPPED", "COMPLETED"])
     def test_delegates_and_updates_tracked_statement(
         self,
         mock_connection_cursor: Cursor,
         statement_response_factory: StatementResponseFactory,
+        returned_phase: str,
     ):
         """stop_statement delegates to the connection (forwarding the flags) and reassigns the
-        cursor's tracked statement to the returned, stopped one."""
+        cursor's tracked statement to whatever terminal Statement the connection returns -- not
+        only STOPPED, but also COMPLETED when a bounded query finished before the stop landed."""
         running = Statement.from_response(
             mock_connection_cursor._connection,
             statement_response_factory(name="stmt-1", phase="RUNNING"),
         )
-        stopped = Statement.from_response(
+        terminal = Statement.from_response(
             mock_connection_cursor._connection,
-            statement_response_factory(name="stmt-1", phase="STOPPED", stopped=True),
+            statement_response_factory(name="stmt-1", phase=returned_phase, stopped=True),
         )
         mock_connection_cursor._statement = running
-        mock_connection_cursor._connection.stop_statement.return_value = stopped  # type: ignore
+        mock_connection_cursor._connection.stop_statement.return_value = terminal  # type: ignore
 
         result = mock_connection_cursor.stop_statement(wait_for_stopped=True, timeout=99)
 
         mock_connection_cursor._connection.stop_statement.assert_called_once_with(  # type: ignore
             "stmt-1", wait_for_stopped=True, timeout=99
         )
-        assert result is stopped
-        assert mock_connection_cursor.statement is stopped
+        assert result is terminal
+        assert mock_connection_cursor.statement is terminal
 
     def test_no_active_statement_raises(self, mock_connection_cursor: Cursor):
         """Stopping with no executed statement raises InterfaceError."""

--- a/tests/unit/test_cursor_unit.py
+++ b/tests/unit/test_cursor_unit.py
@@ -1865,7 +1865,7 @@ class TestStopStatement:
         )
         stopped = Statement.from_response(
             mock_connection_cursor._connection,
-            statement_response_factory(name="stmt-1", phase="STOPPED"),
+            statement_response_factory(name="stmt-1", phase="STOPPED", stopped=True),
         )
         mock_connection_cursor._statement = running
         mock_connection_cursor._connection.stop_statement.return_value = stopped  # type: ignore

--- a/tests/unit/test_cursor_unit.py
+++ b/tests/unit/test_cursor_unit.py
@@ -221,6 +221,36 @@ class TestExecute:
 
         assert sleep_mock.called, "Expected time.sleep to have been called during wait loop."
 
+    def test_first_poll_elapsed_counts_against_timeout(
+        self,
+        mock_connection_cursor: Cursor,
+        statement_response_factory: StatementResponseFactory,
+        mocker,
+    ):
+        """The timeout budget covers the initial poll, not just the paced retries: the monotonic
+        origin captured *before* the first poll is handed to sleep_with_backoff via started_at, so
+        a slow first poll cannot push total wall time past the requested timeout."""
+        pending_statement = statement_response_factory(phase="PENDING")
+
+        # A clock that only advances when the first poll runs, so we can prove started_at was
+        # captured before that poll consumed any time.
+        clock = {"now": 0.0}
+        mocker.patch("time.monotonic", side_effect=lambda: clock["now"])
+
+        def slow_first_poll(*_args, **_kwargs):
+            clock["now"] += 5.0
+            return pending_statement
+
+        mock_connection_cursor._connection._get_statement.side_effect = slow_first_poll  # type: ignore
+
+        # Stub the pacer so the loop body never runs; we only assert how it was invoked.
+        backoff = mocker.patch("confluent_sql.cursor.sleep_with_backoff", return_value=iter([]))
+
+        with pytest.raises(OperationalError, match="Statement submission timed out"):
+            mock_connection_cursor.execute("SELECT 1 AS col", timeout=30)
+
+        backoff.assert_called_once_with(30, started_at=0.0)
+
     @pytest.mark.parametrize(
         "streaming_mode",
         [ExecutionMode.STREAMING_QUERY, ExecutionMode.STREAMING_DDL],

--- a/tests/unit/test_cursor_unit.py
+++ b/tests/unit/test_cursor_unit.py
@@ -230,7 +230,7 @@ class TestExecute:
         """The timeout budget covers the initial poll, not just the paced retries: the monotonic
         origin captured *before* the first poll is handed to sleep_with_backoff via started_at, so
         a slow first poll cannot push total wall time past the requested timeout."""
-        pending_statement = statement_response_factory(phase="PENDING")
+        pending_statement = statement_response_factory(phase="PENDING", null_schema=True)
 
         # A clock that only advances when the first poll runs, so we can prove started_at was
         # captured before that poll consumed any time.

--- a/tests/unit/test_cursor_unit.py
+++ b/tests/unit/test_cursor_unit.py
@@ -1816,3 +1816,40 @@ class TestComputePoolIdParameter:
                 "SELECT 1",
                 compute_pool_id=12345  # Invalid: int instead of str
             )
+
+
+@pytest.mark.unit
+class TestStopStatement:
+    """Tests for Cursor.stop_statement."""
+
+    def test_delegates_and_updates_tracked_statement(
+        self,
+        mock_connection_cursor: Cursor,
+        statement_response_factory: StatementResponseFactory,
+    ):
+        """stop_statement delegates to the connection (forwarding the flags) and reassigns the
+        cursor's tracked statement to the returned, stopped one."""
+        running = Statement.from_response(
+            mock_connection_cursor._connection,
+            statement_response_factory(name="stmt-1", phase="RUNNING"),
+        )
+        stopped = Statement.from_response(
+            mock_connection_cursor._connection,
+            statement_response_factory(name="stmt-1", phase="STOPPED"),
+        )
+        mock_connection_cursor._statement = running
+        mock_connection_cursor._connection.stop_statement.return_value = stopped  # type: ignore
+
+        result = mock_connection_cursor.stop_statement(wait_for_stopped=True, timeout=99)
+
+        mock_connection_cursor._connection.stop_statement.assert_called_once_with(  # type: ignore
+            "stmt-1", wait_for_stopped=True, timeout=99
+        )
+        assert result is stopped
+        assert mock_connection_cursor.statement is stopped
+
+    def test_no_active_statement_raises(self, mock_connection_cursor: Cursor):
+        """Stopping with no executed statement raises InterfaceError."""
+        mock_connection_cursor._statement = None
+        with pytest.raises(InterfaceError, match="No active statement to stop"):
+            mock_connection_cursor.stop_statement()

--- a/tests/unit/test_polling_unit.py
+++ b/tests/unit/test_polling_unit.py
@@ -69,6 +69,32 @@ class TestSleepWithBackoff:
         assert list(sleep_with_backoff(0.0)) == []
         assert fake_clock.slept == []
 
+    def test_jitter_never_exceeds_ceiling(self, mocker):
+        """Even at maximum upward jitter, no individual sleep exceeds the 30s ceiling -- the cap
+        applies to the jittered sleep, not merely to the pre-jitter base delay."""
+        clock = _FakeClock()
+        mocker.patch.object(polling.time, "monotonic", clock.monotonic)
+        mocker.patch.object(polling.time, "sleep", clock.sleep)
+        mocker.patch.object(polling.random, "uniform", return_value=1.25)
+
+        list(sleep_with_backoff(1000.0))
+
+        # Pre-jitter delay caps at 30s; 30 * 1.25 would be 37.5s without a post-jitter clamp.
+        assert max(clock.slept) == 30.0
+
+    def test_started_at_counts_prior_elapsed_against_budget(self, fake_clock: _FakeClock):
+        """A caller that made its own first attempt can pass started_at so the time already spent
+        (e.g. the initial network poll) counts against the timeout, keeping total wall time from
+        that origin within the timeout."""
+        # Simulate 3s already consumed before pacing begins.
+        fake_clock.now = 3.0
+
+        list(sleep_with_backoff(10.0, started_at=0.0))
+
+        # Budget is 10s measured from t=0; 3s already gone leaves ~7s of sleeping.
+        assert sum(fake_clock.slept) == pytest.approx(7.0)
+        assert fake_clock.now == pytest.approx(10.0)
+
     def test_jitter_band_applied(self, mocker):
         """Each sleep is scaled by a ±25% jitter draw."""
         clock = _FakeClock()

--- a/tests/unit/test_polling_unit.py
+++ b/tests/unit/test_polling_unit.py
@@ -1,0 +1,68 @@
+import pytest
+
+from confluent_sql import polling
+from confluent_sql.polling import sleep_with_backoff
+
+
+class _FakeClock:
+    """A monotonic clock that only advances when sleep() is called, so backoff pacing can be
+    exercised deterministically without real time passing."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.slept: list[float] = []
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, secs: float) -> None:
+        self.slept.append(secs)
+        self.now += secs
+
+
+@pytest.fixture()
+def fake_clock(mocker) -> _FakeClock:
+    """Install a fake clock and disable jitter (uniform -> 1.0) inside the polling module."""
+    clock = _FakeClock()
+    mocker.patch.object(polling.time, "monotonic", clock.monotonic)
+    mocker.patch.object(polling.time, "sleep", clock.sleep)
+    mocker.patch.object(polling.random, "uniform", return_value=1.0)
+    return clock
+
+
+@pytest.mark.unit
+class TestSleepWithBackoff:
+    """Tests for the shared backoff pacing generator."""
+
+    def test_sleeps_grow_geometrically_until_timeout(self, fake_clock: _FakeClock):
+        """Each retry sleeps base * growth**n (jitter pinned to 1.0), and yielding stops once the
+        accumulated wait reaches the timeout."""
+        yields = list(sleep_with_backoff(10.0))
+
+        # base=1.0, growth=1.5: 1.0, 1.5, 2.25, 3.375, 5.0625 -> cumulative 13.1875 > 10 after 5.
+        assert fake_clock.slept == [1.0, 1.5, 2.25, 3.375, 5.0625]
+        assert len(yields) == len(fake_clock.slept) == 5
+
+    def test_delay_is_capped(self, fake_clock: _FakeClock):
+        """The per-retry sleep never exceeds the 30s ceiling, even after many retries."""
+        list(sleep_with_backoff(500.0))
+
+        assert max(fake_clock.slept) == 30.0
+        # Once the ceiling is hit it stays there.
+        assert fake_clock.slept[-1] == 30.0
+
+    def test_zero_timeout_yields_nothing(self, fake_clock: _FakeClock):
+        """A non-positive timeout produces no retries and never sleeps."""
+        assert list(sleep_with_backoff(0.0)) == []
+        assert fake_clock.slept == []
+
+    def test_jitter_band_applied(self, mocker):
+        """Each sleep is scaled by a ±25% jitter draw."""
+        clock = _FakeClock()
+        mocker.patch.object(polling.time, "monotonic", clock.monotonic)
+        mocker.patch.object(polling.time, "sleep", clock.sleep)
+        uniform = mocker.patch.object(polling.random, "uniform", return_value=1.0)
+
+        list(sleep_with_backoff(2.0))
+
+        uniform.assert_called_with(0.75, 1.25)

--- a/tests/unit/test_polling_unit.py
+++ b/tests/unit/test_polling_unit.py
@@ -34,22 +34,35 @@ def fake_clock(mocker) -> _FakeClock:
 class TestSleepWithBackoff:
     """Tests for the shared backoff pacing generator."""
 
-    def test_sleeps_grow_geometrically_until_timeout(self, fake_clock: _FakeClock):
-        """Each retry sleeps base * growth**n (jitter pinned to 1.0), and yielding stops once the
-        accumulated wait reaches the timeout."""
+    def test_sleeps_grow_geometrically_then_clamp_to_timeout(self, fake_clock: _FakeClock):
+        """Each retry sleeps base * growth**n (jitter pinned to 1.0); the final sleep is clamped to
+        the remaining budget so the cumulative wait equals -- and never exceeds -- the timeout."""
         yields = list(sleep_with_backoff(10.0))
 
-        # base=1.0, growth=1.5: 1.0, 1.5, 2.25, 3.375, 5.0625 -> cumulative 13.1875 > 10 after 5.
-        assert fake_clock.slept == [1.0, 1.5, 2.25, 3.375, 5.0625]
+        # base=1.0, growth=1.5: 1.0, 1.5, 2.25, 3.375 -> cumulative 8.125; the next full step
+        # (5.0625) would overshoot, so it is clamped to the remaining 1.875.
+        assert fake_clock.slept == [1.0, 1.5, 2.25, 3.375, 1.875]
+        assert sum(fake_clock.slept) == 10.0
         assert len(yields) == len(fake_clock.slept) == 5
 
     def test_delay_is_capped(self, fake_clock: _FakeClock):
-        """The per-retry sleep never exceeds the 30s ceiling, even after many retries."""
+        """The per-retry sleep never exceeds the 30s ceiling, even after many retries, and the
+        total wait still lands exactly on the timeout (final sleep clamped to the remainder)."""
         list(sleep_with_backoff(500.0))
 
         assert max(fake_clock.slept) == 30.0
-        # Once the ceiling is hit it stays there.
-        assert fake_clock.slept[-1] == 30.0
+        # The ceiling is held on interior retries; only the last sleep is clamped down.
+        assert fake_clock.slept[-2] == 30.0
+        assert sum(fake_clock.slept) == pytest.approx(500.0)
+        assert fake_clock.slept[-1] < 30.0
+
+    def test_small_timeout_does_not_overshoot(self, fake_clock: _FakeClock):
+        """A sub-base-delay timeout sleeps only the remaining budget and yields once, rather than
+        sleeping a full base delay (up to 1.25s with jitter) past the requested deadline."""
+        yields = list(sleep_with_backoff(0.1))
+
+        assert fake_clock.slept == [0.1]
+        assert len(yields) == 1
 
     def test_zero_timeout_yields_nothing(self, fake_clock: _FakeClock):
         """A non-positive timeout produces no retries and never sleeps."""

--- a/tests/unit/test_polling_unit.py
+++ b/tests/unit/test_polling_unit.py
@@ -95,6 +95,23 @@ class TestSleepWithBackoff:
         assert sum(fake_clock.slept) == pytest.approx(7.0)
         assert fake_clock.now == pytest.approx(10.0)
 
+    def test_caller_work_between_yields_is_charged_against_budget(self, fake_clock: _FakeClock):
+        """Time the caller spends between yields (e.g. a network GET) counts against the timeout,
+        so a slow caller ends pacing sooner -- the budget is shared across sleeps and caller work,
+        not reset per retry. The generator cannot bound the caller's own in-flight work, though:
+        total wall time can still exceed the timeout by the duration of work already underway."""
+        yields = 0
+        for _ in sleep_with_backoff(10.0):
+            yields += 1
+            fake_clock.now += 4.0  # simulate a 4s caller GET in each loop body
+
+        # sleep 1.0 (t=1) + work (t=5); sleep 1.5 (t=6.5) + work (t=10.5); next check 10.5 > 10.
+        assert yields == 2
+        assert fake_clock.slept == [1.0, 1.5]
+        # Caller work pushed total wall time past the 10s timeout -- the helper bounds its sleeping,
+        # not the caller's GETs.
+        assert fake_clock.now == pytest.approx(10.5)
+
     def test_jitter_band_applied(self, mocker):
         """Each sleep is scaled by a ±25% jitter draw."""
         clock = _FakeClock()

--- a/tests/unit/test_statement_unit.py
+++ b/tests/unit/test_statement_unit.py
@@ -139,6 +139,45 @@ class TestStatementProperties:
         statement = Statement.from_response(mock_connection, statement_json)
         assert statement.is_running == expected
 
+    @pytest.mark.parametrize(
+        "phase,expected_stopped,expected_stopping",
+        [
+            ("STOPPED", True, False),
+            ("STOPPING", False, True),
+            ("RUNNING", False, False),
+            ("COMPLETED", False, False),
+            ("FAILED", False, False),
+        ],
+    )
+    def test_is_stopped_and_is_stopping(
+        self,
+        mock_connection: Connection,
+        statement_response_factory: StatementResponseFactory,
+        phase: str,
+        expected_stopped: bool,
+        expected_stopping: bool,
+    ):
+        """is_stopped is true only for STOPPED; is_stopping only for STOPPING."""
+        statement_json = statement_response_factory(phase=phase)
+        statement = Statement.from_response(mock_connection, statement_json)
+        assert statement.is_stopped == expected_stopped
+        assert statement.is_stopping == expected_stopping
+
+    def test_stop_requested_reflects_spec_stopped(
+        self,
+        mock_connection: Connection,
+        statement_response_factory: StatementResponseFactory,
+    ):
+        """stop_requested mirrors spec.stopped -- true once a stop has been requested, even while
+        the phase still reports RUNNING (the server transitions phase asynchronously)."""
+        not_yet = statement_response_factory(name="s", phase="RUNNING")
+        assert not_yet["spec"]["stopped"] is False
+        assert Statement.from_response(mock_connection, not_yet).stop_requested is False
+
+        requested = statement_response_factory(name="s", phase="RUNNING")
+        requested["spec"]["stopped"] = True
+        assert Statement.from_response(mock_connection, requested).stop_requested is True
+
     def test_type_converter_raises_if_no_schema(
         self, mock_connection: Connection, statement_response_factory: StatementResponseFactory
     ):


### PR DESCRIPTION
## Stopping statements

- Adds `connection.stop_statement(statement, *, wait_for_stopped=True, timeout=300)` so callers
  can halt a running Flink statement while keeping the statement resource around for inspection.
  Until now the only lever was `delete_statement()`, which stops _and_ destroys the statement
  and its results.
- The stop is issued as an RFC 6902 JSON Patch (`[{"op":"replace","path":"/spec/stopped","value":true}]`)
  against `PATCH /statements/{name}` with `Content-Type: application/json-patch+json`.
- **Real-API note:** the PATCH 200 response reflects that the stop was _accepted_ (`spec.stopped`
  flips to `true`), but its `status.phase` may still read `RUNNING` at that instant — the server
  transitions through `STOPPING` to `STOPPED` asynchronously. Issue #61 assumed the response would
  already be `STOPPING`; integration testing against the live environment proved otherwise.
- `wait_for_stopped=True` (the default) refresh-loops — exponential backoff with jitter, via the
  shared `polling.sleep_with_backoff` helper (see below) — until the statement reaches a terminal
  phase (normally `STOPPED`, or `COMPLETED` if a bounded query finished before the stop landed),
  so the caller knows the statement is no longer running before the call returns. The wait evaluates
  the state it already holds (the PATCH response) before its first re-fetch: the phase transitions
  asynchronously, so an immediate GET would almost certainly just re-report the non-terminal phase
  we already have. `wait_for_stopped=False` returns as soon as the stop is accepted; callers can
  confirm acceptance via the new `Statement.stop_requested` property (`spec.stopped`), since the
  phase is not yet a reliable signal.
- A `Statement` already in a terminal phase short-circuits without an API call. A 404 surfaces as
  `StatementNotFoundError` (a missing statement is a real failure for _stop_, unlike _delete_
  where a missing statement already satisfies the goal); other non-2xx map to `OperationalError`.
  A statement that transitions to `FAILED` while waiting raises `OperationalError`.

- Adds `cursor.stop_statement(...)`, mirroring `cursor.delete_statement()`, delegating to the
  connection and updating the cursor's tracked statement with the returned (stopped) object.

- Adds `Statement.is_stopped` / `Statement.is_stopping` / `Statement.stop_requested` properties
  alongside the existing `is_running` / `is_failed`, for clean state checks.

## Shared polling backoff

The new blocking stop wait needed the same exponential-backoff-with-jitter pacing the cursor's
statement-submission wait already used, so rather than copy it, the pacing policy is extracted
into a small internal `polling` module.

- New `polling.sleep_with_backoff(timeout_secs)` — a stateless generator that single-sources the
  backoff policy (base 1.0s, ×1.5 growth, 30s ceiling, ±25% jitter, all module-level constants).
  It sleeps-then-yields, so a caller makes its own immediate first attempt and the generator only
  paces the _retries_; the caller raises its own timeout error once the generator stops yielding.
  Each sleep is clamped to both the remaining budget and the 30s ceiling (jitter included — the
  cap is on the actual sleep, not the pre-jitter base delay, so a ×1.25 jitter draw can't push a
  30s step to 37.5s). The total wait therefore never exceeds `timeout_secs` — the timeout is a
  hard upper bound, not an approximate target, which keeps the callers' own "did not … within N
  seconds" errors literally true. The final paced retry lands right at the deadline rather than
  running a full backoff step past it. An optional `started_at` lets a caller fold a timed first
  attempt into the budget (see below). Kept un-exported from `__init__.py` to signal it is internal.
- `Connection._wait_for_statement_stopped` and `Cursor._wait_for_statement_ready` both consume it
  as `for _ in sleep_with_backoff(timeout, started_at=...):`, each preceded by an explicit first
  attempt. The cursor captures `time.monotonic()` before its first poll and passes it as
  `started_at`, so that poll's network latency counts against the timeout rather than stacking on
  top of it; the connection waiter's first attempt is just re-reading already-held state, so it
  defaults the origin. This drops the two hand-rolled timing loops (deadline math, jitter, growth)
  in favour of one tested one.
- New `tests/unit/test_polling_unit.py` pins the policy with a deterministic fake clock: the
  geometric sleep sequence clamped to land exactly on the timeout, the 30s cap (including under
  maximum jitter), the `started_at` budget accounting, the no-overshoot guarantee for a
  sub-base-delay timeout, the no-yield-on-zero-timeout case, and that the jitter band is applied.

## Relationships

Closes #61