### PR TITLE
Make `compute_pool_id` optional end-to-end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this dbapi driver will be documented in this file.
 
 ## Unreleased
 
+### Changed
+
+- Support for "poolless Flink": `confluent_sql.connect()` now treats `compute_pool_id` as optional. Statements submitted w/o their own overriding `compute_pool_id` via a connection w/o a default compute pool id will make use of the default compute pool in the environment+cloud region (provisioning one if necessary). See [the Confluent documentation](https://docs.confluent.io/cloud/current/flink/concepts/compute-pools.html#default-compute-pools) for more details.
+
 ## 0.3.1, 2026-05-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ All notable changes to this dbapi driver will be documented in this file.
 
 ### Added
 
+- Support for "poolless Flink": `confluent_sql.connect()` now treats `compute_pool_id` as optional. Statements submitted w/o their own overriding `compute_pool_id` via a connection w/o a default compute pool id will make use of the default compute pool in the environment+cloud region (provisioning one if necessary). See [the Confluent documentation](https://docs.confluent.io/cloud/current/flink/concepts/compute-pools.html#default-compute-pools) for more details.
 - New `Connection.stop_statement(statement, *, wait_for_stopped=True, timeout=300)` method to stop a running statement without deleting it, leaving the statement resource around for inspection (unlike `delete_statement()`, which also destroys it). Accepts a statement name or a `Statement` object. By default it blocks until the statement reaches `STOPPED`; pass `wait_for_stopped=False` to return as soon as the stop is accepted. A matching `Cursor.stop_statement()` stops the cursor's current statement. New `Statement.is_stopped`, `Statement.is_stopping`, and `Statement.stop_requested` properties expose the relevant state. (#61)
 
 ### Changed
 
-- Support for "poolless Flink": `confluent_sql.connect()` now treats `compute_pool_id` as optional. Statements submitted w/o their own overriding `compute_pool_id` via a connection w/o a default compute pool id will make use of the default compute pool in the environment+cloud region (provisioning one if necessary). See [the Confluent documentation](https://docs.confluent.io/cloud/current/flink/concepts/compute-pools.html#default-compute-pools) for more details.
 - `Connection.list_statements()`:
   - New optional parameter `compute_pool_id` to list statements only in a single compute pool (otherwise environment-wide).
   - New optional parameter `name_contains: str` to filter statements server-side to those whose name contains the given substring (case-sensitive).

--- a/README.md
+++ b/README.md
@@ -19,13 +19,12 @@ The behavior of snapshot-mode cursors, complying with dbapi semantics, are well 
 ## Prerequisites
 
 - **Confluent Cloud account** with Flink environment
-- **Active Flink compute pool** (must be pre-created)
 - **Existing Flink Database** (Confluent Cloud Kafka cluster)
 - **Flink Region API credentials** for Flink SQL Region API access: a user or service account Flink region API key and secret.
 
 ### How to Obtain a Flink Region API Key
 
-This driver requires a **Flink Region API key** (also called a Flink SQL API key), which is specific to your Flink compute pool and provides access to the regional Flink SQL API endpoints. This is distinct from a Confluent Cloud control-plane API key.
+This driver requires a **Flink Region API key** (also called a Flink SQL API key), which is specific to your Flink region/environment (the environment + cloud provider + cloud region triplet) and provides access to the regional Flink SQL API endpoints. This is distinct from a Confluent Cloud control-plane API key.
 
 To create or find a Flink Region API key:
 
@@ -35,12 +34,13 @@ To create or find a Flink Region API key:
 4. When creating a new key, select either:
    - **My account** - for development/testing
    - **Service account** - for production applications (recommended)
-   and then:   
+     and then:
    - **The Environment, Cloud Provider and Cloud Region** matching the Flink database(s) / Kafka cluster(s) you intend to use this driver against.
 5. Save both the **API key** and **API secret** securely (the secret cannot be retrieved later)
 6. Use these credentials as the `flink_api_key` and `flink_api_secret` parameters in the `connect()` function
 
 API keys may also be generated using the Confluent CLI or by API access, outside the scope of this document.
+
 ## Installation
 
 ```bash
@@ -67,7 +67,7 @@ connection = confluent_sql.connect(
     flink_api_key="your-flink-api-key",
     flink_api_secret="your-flink-api-secret",
     database="your-database-name",
-    compute_pool_id="lfcp-789012"
+    compute_pool_id="lfcp-789012"  # optional; omit to use the environment's default compute pool
 )
 ```
 
@@ -167,15 +167,15 @@ For detailed streaming query guidance, see **[STREAMING.md](https://github.com/c
 
 For type support and examples, see **[TYPES.md](https://github.com/confluentinc/confluent-sql/blob/main/TYPES.md)**.
 
-
 ## Private Networking Considerations
 
 By default, this driver uses the public Confluent Cloud API networking endpoint for the provided cloud provider and region. However, if the Flink database / Kafka cluster you intend to query requires private networking connectivity, then provide the appropriate Flink private networking base URL as the `endpoint` parameter
 to `connect()` or `Connection.__init__()`. Refer to the Confluent Cloud [Flink private networking documentation](https://docs.confluent.io/cloud/current/flink/concepts/flink-private-networking.html) for more information on composing your endpoint URL.
 
 Symptoms of using the public endpoint when private networking is required include:
-  * HTTP 429-related exceptions raised when submitting statements querying tables whose backing Kafka topics / clusters are configured for private networking only.
-  * Empty or surprisingly missing results when querying `INFORMATION_SCHEMA` or `SHOW TABLES`, due to silent filtering of private-networking-only tables/topics when querying the system catalog.
+
+- HTTP 429-related exceptions raised when submitting statements querying tables whose backing Kafka topics / clusters are configured for private networking only.
+- Empty or surprisingly missing results when querying `INFORMATION_SCHEMA` or `SHOW TABLES`, due to silent filtering of private-networking-only tables/topics when querying the system catalog.
 
 ## Development
 
@@ -208,7 +208,7 @@ export CONFLUENT_CLOUD_PROVIDER="aws"
 export CONFLUENT_CLOUD_REGION="us-east-2"
 export CONFLUENT_FLINK_API_KEY="your-key" # Flink Region API key for the above cloud/region ...
 export CONFLUENT_FLINK_API_SECRET="your-secret" # and associated secret.
-export CONFLUENT_COMPUTE_POOL_ID="lfcp-789012" # A compute pool within the above cloud/region.
+export CONFLUENT_COMPUTE_POOL_ID="lfcp-789012" # Optional; a compute pool within the above cloud/region. Leave unset to use the environment default.
 export CONFLUENT_TEST_DBNAME="test-db" # A database/kafka cluster name within the above cloud/region.
 ```
 

--- a/README.md
+++ b/README.md
@@ -208,8 +208,8 @@ export CONFLUENT_CLOUD_PROVIDER="aws"
 export CONFLUENT_CLOUD_REGION="us-east-2"
 export CONFLUENT_FLINK_API_KEY="your-key" # Flink Region API key for the above cloud/region ...
 export CONFLUENT_FLINK_API_SECRET="your-secret" # and associated secret.
-export CONFLUENT_COMPUTE_POOL_ID="lfcp-789012" # Optional; a compute pool within the above cloud/region. Leave unset to use the environment default.
 export CONFLUENT_TEST_DBNAME="test-db" # A database/kafka cluster name within the above cloud/region.
+export CONFLUENT_COMPUTE_POOL_ID="lfcp-789012" # Optional. If set, the integration suite runs against this pool; if unset, the suite runs against the environment's default pool. The driver treats it as optional at connect() either way.
 ```
 
 Run tests:

--- a/src/confluent_sql/connection.py
+++ b/src/confluent_sql/connection.py
@@ -1028,15 +1028,15 @@ class Connection:
         merged_properties = self._resolve_properties(properties, execution_mode)
 
         # Prefer the per-call compute pool over the connection default; either may be absent.
-        if compute_pool_id is not None and self.compute_pool_id:
+        # A falsy per-call value (None or "") means "unspecified" -- matching connect()'s
+        # treatment of "" -- so it defers to the connection default rather than overriding it.
+        if compute_pool_id and self.compute_pool_id:
             # Replacing an actual connection default -- make the swap visible to the caller.
             logger.info(
                 f"execute_statement(): Overriding connection compute_pool_id"
                 f" '{self.compute_pool_id}' with provided compute_pool_id '{compute_pool_id}'"
             )
-        resolved_compute_pool_id = (
-            compute_pool_id if compute_pool_id is not None else self.compute_pool_id
-        )
+        resolved_compute_pool_id = compute_pool_id or self.compute_pool_id
 
         spec: dict[str, Any] = {
             "statement": statement,

--- a/src/confluent_sql/connection.py
+++ b/src/confluent_sql/connection.py
@@ -141,11 +141,11 @@ def connect(  # noqa: PLR0913
         flink_api_key,
         flink_api_secret,
         environment_id,
-        compute_pool_id,
         organization_id,
         cloud_provider,
         cloud_region,
         endpoint,
+        compute_pool_id=compute_pool_id,
         database=database or dbname,  # dbname is deprecated.
         statement_results_page_fetch_pause_millis=result_page_fetch_pause_millis,
         http_user_agent=http_user_agent,
@@ -201,11 +201,11 @@ class Connection:
         flink_api_key: str,
         flink_api_secret: str,
         environment_id: str,
-        compute_pool_id: str | None,
         organization_id: str,
         cloud_provider: str | None,
         cloud_region: str | None,
         endpoint: str | None,
+        compute_pool_id: str | None = None,
         database: str | None = None,
         statement_results_page_fetch_pause_millis: int = 100,
         http_user_agent: str | None = None,
@@ -218,9 +218,6 @@ class Connection:
             flink_api_key: Flink region API key
             flink_api_secret: Flink region API secret
             environment_id: Environment ID
-            compute_pool_id: Optional compute pool ID for SQL execution. If None, statements
-                created on this connection name no pool and Confluent Cloud Flink runs them in
-                the environment+region default compute pool.
             organization_id: Organization ID
             cloud_provider: Cloud provider (required if endpoint is not provided)
             cloud_region: Cloud region (e.g., "us-east-2", "us-west-2"). Required if endpoint is
@@ -233,6 +230,9 @@ class Connection:
                 If your Kafka clusters / Flink tables require private networking, supply the base
                 endpoint URL here (`"https://flink.us-east-2.aws.private.confluent.cloud"` for
                 example, but cases and private networking technologies vary).
+            compute_pool_id: Optional compute pool ID for SQL execution. If omitted (None) or
+                empty, statements created on this connection name no pool and Confluent Cloud
+                Flink runs them in the environment+region default compute pool.
             database: The name of the database to use (optional)
             result_page_fetch_pause_millis: Milliseconds to possibly wait between fetching pages of
                 statement results. Defaults to 100ms. If most recent fetch of results for a
@@ -246,7 +246,9 @@ class Connection:
                            of 5 seconds applies.
         """
         self.environment_id = environment_id
-        self.compute_pool_id = compute_pool_id
+        # Fold a falsy pool ("" or None) into None so the attribute honestly reports the
+        # absence of a default pool rather than carrying an unusable empty string.
+        self.compute_pool_id = compute_pool_id or None
         self.organization_id = organization_id
 
         if statement_results_page_fetch_pause_millis < 0:

--- a/src/confluent_sql/connection.py
+++ b/src/confluent_sql/connection.py
@@ -1032,7 +1032,7 @@ class Connection:
         # Prefer the per-call compute pool over the connection default; either may be absent.
         # A falsy per-call value (None or "") means "unspecified" -- matching connect()'s
         # treatment of "" -- so it defers to the connection default rather than overriding it.
-        if compute_pool_id and self.compute_pool_id:
+        if compute_pool_id and self.compute_pool_id and compute_pool_id != self.compute_pool_id:
             # Replacing an actual connection default -- make the swap visible to the caller.
             logger.info(
                 f"execute_statement(): Overriding connection compute_pool_id"

--- a/src/confluent_sql/connection.py
+++ b/src/confluent_sql/connection.py
@@ -39,8 +39,8 @@ def connect(  # noqa: PLR0913
     flink_api_key: str,
     flink_api_secret: str,
     environment_id: str,
-    compute_pool_id: str,
     organization_id: str,
+    compute_pool_id: str | None = None,
     cloud_provider: str | None = None,
     cloud_region: str | None = None,
     database: str | None = None,
@@ -57,8 +57,12 @@ def connect(  # noqa: PLR0913
         flink_api_key: Flink region API key
         flink_api_secret: Flink region API secret
         environment_id: Environment ID
-        compute_pool_id: Compute pool ID for SQL execution
         organization_id: Organization ID
+        compute_pool_id: Optional compute pool ID for SQL execution. If omitted, statements
+            created on this connection name no pool, so Confluent Cloud Flink runs them in
+            the environment+region default compute pool (provisioning if necessary). Individual
+            statement submission methods may still override or specify a compute pool id on a
+            per-statement basis.
         cloud_provider: Cloud provider (e.g., "aws", "gcp", "azure"). Required if endpoint is not
             provided; must not be provided if endpoint is specified.
         cloud_region: Cloud region (e.g., "us-east-2", "us-west-2"). Required if endpoint is not
@@ -102,9 +106,6 @@ def connect(  # noqa: PLR0913
 
     if not environment_id:
         raise InterfaceError("Environment ID is required")
-
-    if not compute_pool_id:
-        raise InterfaceError("Compute pool ID is required")
 
     if not organization_id:
         raise InterfaceError("Organization ID is required")
@@ -166,7 +167,7 @@ class Connection:
 
     environment_id: str
     organization_id: str
-    compute_pool_id: str
+    compute_pool_id: str | None
     statement_results_page_fetch_pause_secs: float
     """Maximum seconds to wait between fetching pages of statement
         results (per statement). Prevents tight loops of requests to the
@@ -200,7 +201,7 @@ class Connection:
         flink_api_key: str,
         flink_api_secret: str,
         environment_id: str,
-        compute_pool_id: str,
+        compute_pool_id: str | None,
         organization_id: str,
         cloud_provider: str | None,
         cloud_region: str | None,
@@ -217,7 +218,9 @@ class Connection:
             flink_api_key: Flink region API key
             flink_api_secret: Flink region API secret
             environment_id: Environment ID
-            compute_pool_id: Compute pool ID for SQL execution
+            compute_pool_id: Optional compute pool ID for SQL execution. If None, statements
+                created on this connection name no pool and Confluent Cloud Flink runs them in
+                the environment+region default compute pool.
             organization_id: Organization ID
             cloud_provider: Cloud provider (required if endpoint is not provided)
             cloud_region: Cloud region (e.g., "us-east-2", "us-west-2"). Required if endpoint is
@@ -580,7 +583,9 @@ class Connection:
             properties: Optional dictionary of statement properties to set for this execution.
                        Keys must be strings, values must be str, int, or bool.
             compute_pool_id: Optional compute pool ID to use for this statement execution.
-                            If not provided, uses the Connection's default compute_pool_id.
+                            If not provided, uses the Connection's default compute_pool_id,
+                            if any; otherwise Confluent Cloud Flink runs the statement in the
+                            environment+region default compute pool.
                             The compute pool must be accessible to the API key used for the
                             connection. Validation of compute pool accessibility is performed
                             by Confluent Cloud Flink.
@@ -638,7 +643,9 @@ class Connection:
             properties: Optional dictionary of statement properties to set for this execution.
                        Keys must be strings, values must be str, int, or bool.
             compute_pool_id: Optional compute pool ID to use for this statement execution.
-                            If not provided, uses the Connection's default compute_pool_id.
+                            If not provided, uses the Connection's default compute_pool_id,
+                            if any; otherwise Confluent Cloud Flink runs the statement in the
+                            environment+region default compute pool.
                             The compute pool must be accessible to the API key used for the
                             connection. Validation of compute pool accessibility is performed
                             by Confluent Cloud Flink.
@@ -991,7 +998,9 @@ class Connection:
                        properties (sql.current-catalog, sql.current-database, sql.snapshot.mode)
                        are always set by the driver and cannot be overridden.
             compute_pool_id: Optional compute pool ID to use for this statement execution.
-                            If not provided, uses the Connection's default compute_pool_id.
+                            If not provided, uses the Connection's default compute_pool_id,
+                            if any; otherwise Confluent Cloud Flink runs the statement in the
+                            environment+region default compute pool.
                             The compute pool must be accessible to the API key used for the
                             connection. Validation of compute pool accessibility is performed
                             by Confluent Cloud Flink.
@@ -1018,27 +1027,33 @@ class Connection:
         # Resolve and merge user properties with system properties
         merged_properties = self._resolve_properties(properties, execution_mode)
 
-        # Use provided compute_pool_id or default to Connection's compute_pool_id
-        if compute_pool_id is not None:
-            # Just so that the user is well aware that this is happening ...
+        # Prefer the per-call compute pool over the connection default; either may be absent.
+        if compute_pool_id is not None and self.compute_pool_id:
+            # Replacing an actual connection default -- make the swap visible to the caller.
             logger.info(
                 f"execute_statement(): Overriding connection compute_pool_id"
                 f" '{self.compute_pool_id}' with provided compute_pool_id '{compute_pool_id}'"
             )
-            resolved_compute_pool_id = compute_pool_id
-        else:
-            resolved_compute_pool_id = self.compute_pool_id
+        resolved_compute_pool_id = (
+            compute_pool_id if compute_pool_id is not None else self.compute_pool_id
+        )
+
+        spec: dict[str, Any] = {
+            "statement": statement,
+            "properties": merged_properties,
+            "stopped": False,
+        }
+
+        # Omit the key entirely when no pool is resolved, letting Flink fall back to the
+        # environment+region default compute pool.
+        if resolved_compute_pool_id:
+            spec["compute_pool_id"] = resolved_compute_pool_id
 
         payload = {
             "name": statement_name,
             "organization_id": self.organization_id,
             "environment_id": self.environment_id,
-            "spec": {
-                "statement": statement,
-                "properties": merged_properties,
-                "compute_pool_id": resolved_compute_pool_id,
-                "stopped": False,
-            },
+            "spec": spec,
         }
 
         if statement_labels is not None:

--- a/src/confluent_sql/cursor.py
+++ b/src/confluent_sql/cursor.py
@@ -207,7 +207,9 @@ class Cursor:
                        properties (sql.current-catalog, sql.current-database, sql.snapshot.mode)
                        are always set by the driver and cannot be overridden.
             compute_pool_id: Optional compute pool ID to use for this statement execution.
-                            If not provided, uses the Connection's default compute_pool_id.
+                            If not provided, uses the Connection's default compute_pool_id,
+                            if any; otherwise Confluent Cloud Flink runs the statement in the
+                            environment+region default compute pool.
                             The compute pool must be accessible to the API key used for the
                             connection. Validation of compute pool accessibility is performed
                             by Confluent Cloud Flink.
@@ -770,7 +772,9 @@ class Cursor:
                              in server logs and UIs (defaults to None)
             properties: Optional dictionary of statement properties (optional)
             compute_pool_id: Optional compute pool ID to use for this statement execution.
-                            If not provided, uses the Connection's default compute_pool_id.
+                            If not provided, uses the Connection's default compute_pool_id,
+                            if any; otherwise Confluent Cloud Flink runs the statement in the
+                            environment+region default compute pool.
 
         Returns:
             The submitted Statement object

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -108,6 +108,51 @@ def connection(load_env_file) -> Generator[Connection, Any, None]:
     conn.close()
 
 
+@pytest.fixture(scope="session")
+def poolless_connection(load_env_file) -> Generator[Connection, Any, None]:
+    """
+    A real connection created without a compute pool, exercising the default-pool path.
+
+    Deliberately does not require (or pass) CONFLUENT_COMPUTE_POOL_ID, so statements
+    submitted through it rely on the environment+region default compute pool (the
+    "Poolless Flink" feature that went GA in Apr 2026).
+    """
+    flink_api_key = os.getenv("CONFLUENT_FLINK_API_KEY", "")
+    flink_api_secret = os.getenv("CONFLUENT_FLINK_API_SECRET", "")
+    environment_id = os.getenv("CONFLUENT_ENV_ID", "")
+    organization_id = os.getenv("CONFLUENT_ORG_ID", "")
+    cloud_provider = os.getenv("CONFLUENT_CLOUD_PROVIDER", "")
+    cloud_region = os.getenv("CONFLUENT_CLOUD_REGION", "")
+    database = os.getenv("CONFLUENT_TEST_DBNAME", "")
+
+    if not all(
+        [
+            flink_api_key,
+            flink_api_secret,
+            environment_id,
+            organization_id,
+            cloud_region,
+            cloud_provider,
+            database,
+        ]
+    ):
+        pytest.skip("Missing required environment variables for integration test")
+
+    conn = confluent_sql.connect(
+        flink_api_key=flink_api_key,
+        flink_api_secret=flink_api_secret,
+        environment_id=environment_id,
+        organization_id=organization_id,
+        cloud_region=cloud_region,
+        cloud_provider=cloud_provider,
+        database=database,
+    )
+
+    yield conn
+
+    conn.close()
+
+
 @pytest.fixture()
 def database():
     """Returns the database name used for integration tests."""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -60,20 +60,18 @@ def filtered_username() -> str:
     return filtered[:10]
 
 
-@pytest.fixture(scope="session")
-def connection(load_env_file) -> Generator[Connection, Any, None]:
-    """
-    Create a real connection for test suite run.
+def _connect_from_env(*, include_compute_pool: bool) -> Connection:
+    """Build a real Connection from CONFLUENT_* env vars for integration tests.
 
-    Will automatically close at the end of the session.
-
-    This uses real api keys (from env).
+    Skips the requesting test if any of the seven universally-required vars is absent.
+    When include_compute_pool is True, CONFLUENT_COMPUTE_POOL_ID is forwarded if set and
+    otherwise left unspecified (Flink falls back to the environment default pool). When
+    False, the pool is never forwarded, forcing the default-pool path even if the var is set.
     """
     flink_api_key = os.getenv("CONFLUENT_FLINK_API_KEY", "")
     flink_api_secret = os.getenv("CONFLUENT_FLINK_API_SECRET", "")
     environment_id = os.getenv("CONFLUENT_ENV_ID", "")
     organization_id = os.getenv("CONFLUENT_ORG_ID", "")
-    compute_pool_id = os.getenv("CONFLUENT_COMPUTE_POOL_ID", "")
     cloud_provider = os.getenv("CONFLUENT_CLOUD_PROVIDER", "")
     cloud_region = os.getenv("CONFLUENT_CLOUD_REGION", "")
     database = os.getenv("CONFLUENT_TEST_DBNAME", "")
@@ -84,7 +82,6 @@ def connection(load_env_file) -> Generator[Connection, Any, None]:
             flink_api_secret,
             environment_id,
             organization_id,
-            compute_pool_id,
             cloud_region,
             cloud_provider,
             database,
@@ -92,16 +89,35 @@ def connection(load_env_file) -> Generator[Connection, Any, None]:
     ):
         pytest.skip("Missing required environment variables for integration test")
 
-    conn = confluent_sql.connect(
+    # Optionally set. If omitted, will run in the default compute pool for the environment+region, provisioning if necessary.
+    maybe_compute_pool_id = (
+        (os.getenv("CONFLUENT_COMPUTE_POOL_ID") or None) if include_compute_pool else None
+    )
+
+    return confluent_sql.connect(
         flink_api_key=flink_api_key,
         flink_api_secret=flink_api_secret,
         environment_id=environment_id,
         organization_id=organization_id,
-        compute_pool_id=compute_pool_id,
+        compute_pool_id=maybe_compute_pool_id,
         cloud_region=cloud_region,
         cloud_provider=cloud_provider,
         database=database,
     )
+
+
+@pytest.fixture(scope="session")
+def connection(load_env_file) -> Generator[Connection, Any, None]:
+    """
+    Create a real connection for test suite run.
+
+    Will automatically close at the end of the session.
+
+    This uses real api keys (from env). Runs against CONFLUENT_COMPUTE_POOL_ID when that
+    var is set, and otherwise against the environment's default compute pool, so the full
+    suite runs in either configuration.
+    """
+    conn = _connect_from_env(include_compute_pool=True)
 
     yield conn
 
@@ -113,40 +129,12 @@ def poolless_connection(load_env_file) -> Generator[Connection, Any, None]:
     """
     A real connection created without a compute pool, exercising the default-pool path.
 
-    Deliberately does not require (or pass) CONFLUENT_COMPUTE_POOL_ID, so statements
-    submitted through it rely on the environment+region default compute pool (the
-    "Poolless Flink" feature that went GA in Apr 2026).
+    Never forwards CONFLUENT_COMPUTE_POOL_ID even when it is set, so statements submitted
+    through it always rely on the environment+region default compute pool (the "Poolless
+    Flink" feature that went GA in Apr 2026). This keeps the default-pool path under test
+    even when a specific pool is configured for the rest of the suite.
     """
-    flink_api_key = os.getenv("CONFLUENT_FLINK_API_KEY", "")
-    flink_api_secret = os.getenv("CONFLUENT_FLINK_API_SECRET", "")
-    environment_id = os.getenv("CONFLUENT_ENV_ID", "")
-    organization_id = os.getenv("CONFLUENT_ORG_ID", "")
-    cloud_provider = os.getenv("CONFLUENT_CLOUD_PROVIDER", "")
-    cloud_region = os.getenv("CONFLUENT_CLOUD_REGION", "")
-    database = os.getenv("CONFLUENT_TEST_DBNAME", "")
-
-    if not all(
-        [
-            flink_api_key,
-            flink_api_secret,
-            environment_id,
-            organization_id,
-            cloud_region,
-            cloud_provider,
-            database,
-        ]
-    ):
-        pytest.skip("Missing required environment variables for integration test")
-
-    conn = confluent_sql.connect(
-        flink_api_key=flink_api_key,
-        flink_api_secret=flink_api_secret,
-        environment_id=environment_id,
-        organization_id=organization_id,
-        cloud_region=cloud_region,
-        cloud_provider=cloud_provider,
-        database=database,
-    )
+    conn = _connect_from_env(include_compute_pool=False)
 
     yield conn
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -89,7 +89,8 @@ def _connect_from_env(*, include_compute_pool: bool) -> Connection:
     ):
         pytest.skip("Missing required environment variables for integration test")
 
-    # Optionally set. If omitted, will run statements in the default compute pool for the environment+region.
+    # Optionally set. If omitted, will run statements in the default compute pool for the
+    # environment+region.
     maybe_compute_pool_id = (
         (os.getenv("CONFLUENT_COMPUTE_POOL_ID") or None) if include_compute_pool else None
     )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -89,7 +89,8 @@ def _connect_from_env(*, include_compute_pool: bool) -> Connection:
     ):
         pytest.skip("Missing required environment variables for integration test")
 
-    # Optionally set. If omitted, will run in the default compute pool for the environment+region, provisioning if necessary.
+    # Optionally set. If omitted, will run in the default compute pool for the environment+region,
+    # provisioning if necessary.
     maybe_compute_pool_id = (
         (os.getenv("CONFLUENT_COMPUTE_POOL_ID") or None) if include_compute_pool else None
     )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -89,7 +89,7 @@ def _connect_from_env(*, include_compute_pool: bool) -> Connection:
     ):
         pytest.skip("Missing required environment variables for integration test")
 
-    # Optionally set. If omitted, will run in the default compute pool for the environment+region.
+    # Optionally set. If omitted, will run statements in the default compute pool for the environment+region.
     maybe_compute_pool_id = (
         (os.getenv("CONFLUENT_COMPUTE_POOL_ID") or None) if include_compute_pool else None
     )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -89,8 +89,7 @@ def _connect_from_env(*, include_compute_pool: bool) -> Connection:
     ):
         pytest.skip("Missing required environment variables for integration test")
 
-    # Optionally set. If omitted, will run in the default compute pool for the environment+region,
-    # provisioning if necessary.
+    # Optionally set. If omitted, will run in the default compute pool for the environment+region.
     maybe_compute_pool_id = (
         (os.getenv("CONFLUENT_COMPUTE_POOL_ID") or None) if include_compute_pool else None
     )

--- a/tests/integration/test_connection.py
+++ b/tests/integration/test_connection.py
@@ -53,7 +53,6 @@ class TestConnection:
         or os.getenv("CONFLUENT_FLINK_API_SECRET") is None
         or os.getenv("CONFLUENT_ENV_ID") is None
         or os.getenv("CONFLUENT_ORG_ID") is None
-        or os.getenv("CONFLUENT_COMPUTE_POOL_ID") is None
         or os.getenv("CONFLUENT_CLOUD_PROVIDER") is None
         or os.getenv("CONFLUENT_CLOUD_REGION") is None,
         reason="Missing confluent environment variables",
@@ -64,7 +63,7 @@ class TestConnection:
         flink_api_secret = os.getenv("CONFLUENT_FLINK_API_SECRET", "")
         environment_id = os.getenv("CONFLUENT_ENV_ID", "")
         organization_id = os.getenv("CONFLUENT_ORG_ID", "")
-        compute_pool_id = os.getenv("CONFLUENT_COMPUTE_POOL_ID", "")
+        compute_pool_id = os.getenv("CONFLUENT_COMPUTE_POOL_ID") or None
         cloud_provider = os.getenv("CONFLUENT_CLOUD_PROVIDER", "")
         cloud_region = os.getenv("CONFLUENT_CLOUD_REGION", "")
         connection = confluent_sql.connect(

--- a/tests/integration/test_connection.py
+++ b/tests/integration/test_connection.py
@@ -92,6 +92,24 @@ class TestConnection:
         # Stop + delete the statement, CCloud-Flink side.
         cursor.close()
 
+    def test_default_compute_pool_when_none_specified(self, poolless_connection: Connection):
+        """A connection without a compute pool runs statements in the environment default.
+
+        Proves the end-to-end #108 path: no compute_pool_id is sent, yet Flink still runs the
+        statement and associates it with a (default) compute pool in the response.
+        """
+        assert poolless_connection.compute_pool_id is None
+
+        with poolless_connection.closing_cursor() as cursor:
+            cursor.execute("SELECT 1 as answer FROM `INFORMATION_SCHEMA`.`TABLES`")
+            row = cursor.fetchone()
+            assert row == (1,)
+
+            # Flink picked a default pool for us even though we named none.
+            assert cursor.statement.compute_pool_id, (
+                "Expected the server to associate the statement with a default compute pool"
+            )
+
     def test_closing_cursor_after_executing_statement(self, connection: Connection, mocker):
         """Test that auto closing a cursor used for a bounded statement works as expected."""
         with connection.closing_cursor() as cursor:

--- a/tests/unit/test_connection_unit.py
+++ b/tests/unit/test_connection_unit.py
@@ -312,7 +312,8 @@ class TestConnectChecks:
         ],
     )
     def test_compute_pool_id_optional(self, compute_pool_id: str | None):
-        """A connection may be created without or a blank compute pool; Flink will use the default compute pool."""
+        """A connection may be created without or a blank compute pool; Flink will use the default
+        compute pool for the env+cloud-region."""
         connection = connect(
             environment_id="foo_id",
             organization_id="org-id",

--- a/tests/unit/test_connection_unit.py
+++ b/tests/unit/test_connection_unit.py
@@ -317,9 +317,30 @@ class TestConnectChecks:
         assert connection.compute_pool_id is None
 
     def test_compute_pool_id_optional_when_empty(self, connection_factory: ConnectionFactory):
-        """An empty compute pool id is accepted and treated as 'no pool specified'."""
+        """An empty compute pool id is folded into None -- 'no pool specified'.
+
+        connect() normalizes "" to None so the stored attribute honestly reports the absence
+        of a default pool rather than carrying an unusable empty string.
+        """
         connection = connection_factory(environment_id="foo_id", compute_pool_id="")
-        assert not connection.compute_pool_id
+        assert connection.compute_pool_id is None
+
+    def test_connection_constructible_without_compute_pool(self):
+        """Connection() is directly constructible without a pool -- optional end-to-end (#108).
+
+        Direct Connection instantiation must not force callers to pass compute_pool_id=None;
+        omitting it leaves the connection poolless.
+        """
+        connection = Connection(
+            flink_api_key="valid-key",
+            flink_api_secret="valid-secret",
+            environment_id="env-id",
+            organization_id="org-id",
+            cloud_provider="aws",
+            cloud_region="us-east-1",
+            endpoint=None,
+        )
+        assert connection.compute_pool_id is None
 
     def test_requires_organization_id(self, connection_factory: ConnectionFactory):
         """Test that creating a connection without an organization ID raises an error."""

--- a/tests/unit/test_connection_unit.py
+++ b/tests/unit/test_connection_unit.py
@@ -1722,6 +1722,38 @@ class TestComputePoolIdParameter:
             "Overriding connection compute_pool_id" in msg for msg in log_messages
         ), f"Override log should not fire without a connection default: {log_messages}"
 
+    @pytest.mark.parametrize("falsy_per_call_pool", [None, ""])
+    def test_execute_statement_falsy_per_call_pool_defers_to_default(
+        self, invalid_credential_connection, mocker, falsy_per_call_pool
+    ):
+        """A falsy per-call pool defers to the connection default, silently.
+
+        Empty string must behave identically to None -- both mean "unspecified" -- matching
+        how connect() folds "" into no-pool. Neither variant overrides anything, so the
+        override log must stay silent.
+        """
+        mock_response = mocker.Mock()
+        mock_response.json.return_value = {
+            "name": "test-statement",
+            "spec": {"compute_pool_id": "cp-id"},
+        }
+        mocker.patch.object(
+            invalid_credential_connection._client, "request", return_value=mock_response
+        )
+        mock_log_info = mocker.patch("confluent_sql.connection.logger.info")
+
+        invalid_credential_connection._execute_statement(
+            "SELECT 1", ExecutionMode.SNAPSHOT, compute_pool_id=falsy_per_call_pool
+        )
+
+        payload = invalid_credential_connection._client.request.call_args.kwargs["json"]
+        assert payload["spec"]["compute_pool_id"] == "cp-id"  # the connection default
+
+        log_messages = [str(call) for call in mock_log_info.call_args_list]
+        assert not any(
+            "Overriding connection compute_pool_id" in msg for msg in log_messages
+        ), f"Falsy per-call pool should not fire the override log: {log_messages}"
+
     def test_execute_statement_validates_compute_pool_type(
         self, invalid_credential_connection
     ):

--- a/tests/unit/test_connection_unit.py
+++ b/tests/unit/test_connection_unit.py
@@ -312,7 +312,7 @@ class TestConnectChecks:
         ],
     )
     def test_compute_pool_id_optional(self, compute_pool_id: str | None):
-        """A connection may be created without a compute pool; Flink picks the env default."""
+        """A connection may be created without or a blank compute pool; Flink will use the default compute pool."""
         connection = connect(
             environment_id="foo_id",
             organization_id="org-id",

--- a/tests/unit/test_connection_unit.py
+++ b/tests/unit/test_connection_unit.py
@@ -34,6 +34,19 @@ def invalid_credential_connection() -> Connection:
     )
 
 
+@pytest.fixture()
+def poolless_connection() -> Connection:
+    """A connection created without a compute pool, exercising the default-pool path."""
+    return connect(
+        environment_id="env-id",
+        organization_id="org-id",
+        cloud_provider="aws",
+        cloud_region="us-east-1",
+        flink_api_key="invalid-key",
+        flink_api_secret="invalid-secret",
+    )
+
+
 def _create_http_error_404():
     """Helper function that raises an HTTPStatusError with a mocked 404 response."""
     mock_response = Mock()
@@ -291,10 +304,22 @@ class TestConnectChecks:
         with pytest.raises(InterfaceError, match="Environment ID is required"):
             connection_factory(environment_id="")
 
-    def test_requires_compute_pool_id(self, connection_factory: ConnectionFactory):
-        """Test that creating a connection without a compute pool ID raises an error."""
-        with pytest.raises(InterfaceError, match="Compute pool ID is required"):
-            connection_factory(environment_id="foo_id", compute_pool_id="")
+    def test_compute_pool_id_optional_when_omitted(self):
+        """A connection may be created without a compute pool; Flink picks the env default."""
+        connection = connect(
+            environment_id="foo_id",
+            organization_id="org-id",
+            cloud_provider="aws",
+            cloud_region="us-east-1",
+            flink_api_key="valid-key",
+            flink_api_secret="valid-secret",
+        )
+        assert connection.compute_pool_id is None
+
+    def test_compute_pool_id_optional_when_empty(self, connection_factory: ConnectionFactory):
+        """An empty compute pool id is accepted and treated as 'no pool specified'."""
+        connection = connection_factory(environment_id="foo_id", compute_pool_id="")
+        assert not connection.compute_pool_id
 
     def test_requires_organization_id(self, connection_factory: ConnectionFactory):
         """Test that creating a connection without an organization ID raises an error."""
@@ -1652,6 +1677,50 @@ class TestComputePoolIdParameter:
         call_kwargs = invalid_credential_connection._client.request.call_args
         payload = call_kwargs.kwargs['json']
         assert payload['spec']['compute_pool_id'] == "cp-id"  # from fixture
+
+    def test_execute_statement_omits_pool_when_none_resolved(
+        self, poolless_connection, mocker
+    ):
+        """With no per-call argument and no connection default, spec carries no pool."""
+        mock_response = mocker.Mock()
+        mock_response.json.return_value = {"name": "test-statement", "spec": {}}
+        mocker.patch.object(poolless_connection._client, "request", return_value=mock_response)
+        mock_log_info = mocker.patch("confluent_sql.connection.logger.info")
+
+        poolless_connection._execute_statement("SELECT 1", ExecutionMode.SNAPSHOT)
+
+        payload = poolless_connection._client.request.call_args.kwargs["json"]
+        assert "compute_pool_id" not in payload["spec"]
+
+        # No connection default means there is nothing to "override" -- stay silent.
+        log_messages = [str(call) for call in mock_log_info.call_args_list]
+        assert not any(
+            "Overriding connection compute_pool_id" in msg for msg in log_messages
+        ), f"Override log should not fire without a connection default: {log_messages}"
+
+    def test_execute_statement_per_call_pool_without_connection_default(
+        self, poolless_connection, mocker
+    ):
+        """A per-call pool is used even with no connection default, without an override log."""
+        mock_response = mocker.Mock()
+        mock_response.json.return_value = {
+            "name": "test-statement",
+            "spec": {"compute_pool_id": "lfcp-explicit"},
+        }
+        mocker.patch.object(poolless_connection._client, "request", return_value=mock_response)
+        mock_log_info = mocker.patch("confluent_sql.connection.logger.info")
+
+        poolless_connection._execute_statement(
+            "SELECT 1", ExecutionMode.SNAPSHOT, compute_pool_id="lfcp-explicit"
+        )
+
+        payload = poolless_connection._client.request.call_args.kwargs["json"]
+        assert payload["spec"]["compute_pool_id"] == "lfcp-explicit"
+
+        log_messages = [str(call) for call in mock_log_info.call_args_list]
+        assert not any(
+            "Overriding connection compute_pool_id" in msg for msg in log_messages
+        ), f"Override log should not fire without a connection default: {log_messages}"
 
     def test_execute_statement_validates_compute_pool_type(
         self, invalid_credential_connection

--- a/tests/unit/test_connection_unit.py
+++ b/tests/unit/test_connection_unit.py
@@ -304,7 +304,14 @@ class TestConnectChecks:
         with pytest.raises(InterfaceError, match="Environment ID is required"):
             connection_factory(environment_id="")
 
-    def test_compute_pool_id_optional_when_omitted(self):
+    @pytest.mark.parametrize(
+        "compute_pool_id",
+        [
+            None,
+            "",
+        ],
+    )
+    def test_compute_pool_id_optional(self, compute_pool_id: str | None):
         """A connection may be created without a compute pool; Flink picks the env default."""
         connection = connect(
             environment_id="foo_id",
@@ -313,16 +320,9 @@ class TestConnectChecks:
             cloud_region="us-east-1",
             flink_api_key="valid-key",
             flink_api_secret="valid-secret",
+            compute_pool_id=compute_pool_id,
         )
-        assert connection.compute_pool_id is None
-
-    def test_compute_pool_id_optional_when_empty(self, connection_factory: ConnectionFactory):
-        """An empty compute pool id is folded into None -- 'no pool specified'.
-
-        connect() normalizes "" to None so the stored attribute honestly reports the absence
-        of a default pool rather than carrying an unusable empty string.
-        """
-        connection = connection_factory(environment_id="foo_id", compute_pool_id="")
+        # Should end up None either way.
         assert connection.compute_pool_id is None
 
     def test_connection_constructible_without_compute_pool(self):


### PR DESCRIPTION
## Optional compute pool id

- Confluent Cloud Flink now supports a per-environment _default compute pool_: if a
  submitted statement names no pool, Flink runs it in (and provisions, if needed) the
  environment+region default. This driver previously forced callers to supply a concrete
  `compute_pool_id`, so it could not reach that path.
- `connect()` and `Connection.__init__()` now treat `compute_pool_id` as optional. When
  omitted, the connection carries no default pool and submitted statements simply leave the
  choice to Flink.
- `Connection._execute_statement()` omits `spec.compute_pool_id` from the submitted statement
  JSON entirely when no pool is resolved (neither a per-call argument nor a connection
  default). A pool is still included whenever one is available, with the per-call argument
  winning over the connection default.
- The per-call override log now fires only when there is an actual connection default being
  replaced — no more misleading "Overriding ... 'None'".
- A falsy per-call `compute_pool_id` (`None` _or_ `""`) means "unspecified" and defers to the
  connection default, matching how `connect()` already folds `""` into no-pool. An empty
  string no longer suppresses the connection default or emits a stray "Overriding ... ''" log.
  A parametrized unit test (`test_execute_statement_falsy_per_call_pool_defers_to_default`)
  pins both falsy variants to the same behaviour.
- A live integration test (`test_default_compute_pool_when_none_specified`) submits a real
  query through a poolless connection and confirms Flink both runs it and echoes back a
  (default) `compute_pool_id` on the resulting statement. That second assertion confirms
  `Statement.compute_pool_id` can stay a plain `str` — the server always populates it.
- The integration suite now runs in either configuration: the shared `connection` fixture
  forwards `CONFLUENT_COMPUTE_POOL_ID` when set and otherwise runs the whole suite against
  the environment default pool (previously it skipped out entirely without the var). A
  dedicated `poolless_connection` fixture always omits the pool, keeping the default-pool
  path under test even when a specific pool is configured. Both fixtures share one
  `_connect_from_env` helper that owns the required-var skip gate.

## Docs

- README prerequisites, the `connect()` example, and the `CONFLUENT_COMPUTE_POOL_ID`
  env-var note now describe the pool as optional.
- API docstring (`connect`, `Connection.__init__`, the cursor/connection execute helpers)
  wording updated to reflect the default-pool fallback.
- CHANGELOG.md entry announcing the new feature.

## Relationships

Closes #108
