### PR TITLE
Initial connector API methods.

### DIFF
--- a/src/confluent_sql/__init__.py
+++ b/src/confluent_sql/__init__.py
@@ -7,9 +7,18 @@ executing SQL queries against Confluent SQL services.
 
 from .changelog_compressor import ChangelogCompressor
 from .connection import Connection, connect
+from .connectors import (
+    Connector,
+    ConnectorSpec,
+    ConnectorState,
+    ConnectorStatus,
+    TaskStatus,
+)
 from .cursor import Cursor
 from .exceptions import (
     ComputePoolExhaustedError,
+    ConnectorAlreadyExistsError,
+    ConnectorNotFoundError,
     DatabaseError,
     DataError,
     Error,
@@ -75,6 +84,13 @@ __all__ = [
     "TypeMismatchError",
     "TableflowTopicNotFoundError",
     "TableflowTopicAlreadyExistsError",
+    "ConnectorNotFoundError",
+    "ConnectorAlreadyExistsError",
+    "Connector",
+    "ConnectorSpec",
+    "ConnectorStatus",
+    "ConnectorState",
+    "TaskStatus",
     "TableFormat",
     "TableflowPhase",
     "TableflowTopic",

--- a/src/confluent_sql/connection.py
+++ b/src/confluent_sql/connection.py
@@ -20,6 +20,7 @@ from typing import Any
 import httpx
 
 from .__version__ import VERSION
+from .connectors import Connector, ConnectorApi
 from .cursor import Cursor
 from .exceptions import (
     InterfaceError,
@@ -43,10 +44,10 @@ from .tableflow import (
     build_create_payload,
     normalize_table_formats,
 )
-from .types import PropertiesDict, RowPythonTypes
+from .types import PropertiesDict, RowPythonTypes, StrAnyDict
 
 DEFAULT_CONTROLPLANE_ENDPOINT = "https://api.confluent.cloud"
-"""Control-plane host for Tableflow and CMK routes -- distinct from the Flink gateway."""
+"""Control-plane host for Tableflow, Connect, and CMK routes -- distinct from the Flink gateway."""
 
 logger = logging.getLogger(__name__)
 
@@ -133,6 +134,39 @@ def _resolve_tableflow_credentials(
     return None
 
 
+def _resolve_connect_credentials(
+    global_api_key: str | None,
+    global_api_secret: str | None,
+    connect_api_key: str | None,
+    connect_api_secret: str | None,
+) -> tuple[str, str] | None:
+    """Pick the (key, secret) pair the Connect control-plane routes authenticate with.
+
+    A global key covers every route, so it wins. Otherwise the Connect routes use the dedicated
+    connect pair (symmetric with the Tableflow pair -- see _resolve_tableflow_credentials). Returns
+    None when neither is available, so the error can be deferred to the first actual connector use
+    rather than raised at connect() time.
+
+    Raises:
+        InterfaceError: If no global key is supplied and the connect pair is half-supplied (key
+            without secret, or vice versa).
+    """
+    global_key, global_secret = global_api_key or "", global_api_secret or ""
+    connect_key, connect_secret = connect_api_key or "", connect_api_secret or ""
+
+    # A global key wins and covers everything, so short-circuit before validating the connect pair:
+    # a caller who supplied a usable global key shouldn't be tripped up by an incidental
+    # half-supplied connect pair (e.g. one leaked in from the environment).
+    if global_key:
+        return (global_key, global_secret)
+
+    if bool(connect_key) != bool(connect_secret):
+        raise InterfaceError("connect_api_key and connect_api_secret must be provided together")
+    if connect_key:
+        return (connect_key, connect_secret)
+    return None
+
+
 def connect(  # noqa: PLR0913
     *,
     global_api_key: str | None = None,
@@ -141,6 +175,8 @@ def connect(  # noqa: PLR0913
     flink_api_secret: str | None = None,
     tableflow_api_key: str | None = None,
     tableflow_api_secret: str | None = None,
+    connect_api_key: str | None = None,
+    connect_api_secret: str | None = None,
     environment_id: str,
     organization_id: str,
     compute_pool_id: str | None = None,
@@ -170,6 +206,10 @@ def connect(  # noqa: PLR0913
             Tableflow). Only consulted when no global key is supplied; a global key already
             covers Tableflow. Must be supplied together with tableflow_api_secret.
         tableflow_api_secret: Secret paired with tableflow_api_key.
+        connect_api_key: API key for the Connect control-plane routes (create/get/delete
+            connectors). Only consulted when no global key is supplied; a global key already
+            covers Connect. Must be supplied together with connect_api_secret.
+        connect_api_secret: Secret paired with connect_api_key.
         environment_id: Environment ID
         organization_id: Organization ID
         compute_pool_id: Optional compute pool ID for SQL execution. If omitted, statements
@@ -184,10 +224,10 @@ def connect(  # noqa: PLR0913
         database: The default Flink database (Kafka cluster) to use when resolving
             table/view/udf names (optional)
         database_kafka_cluster_id: The `lkc-…` id of the Kafka cluster backing `database`
-            (optional). Supplying it lets the Tableflow methods skip the CMK name→id lookup
-            (which needs a global/cloud key), so Tableflow works with only a Tableflow key pair.
-            Omitted, the id is resolved lazily from `database` via CMK on first Tableflow use,
-            which requires a global key.
+            (optional). Supplying it lets the Tableflow and connector methods skip the CMK
+            name→id lookup (which needs a global/cloud key), so they work with only their
+            dedicated key pair. Omitted, the id is resolved lazily from `database` via CMK on
+            first such use, which requires a global key.
         endpoint: The base URL for Confluent Cloud API (optional). If not provided, the public
             networking endpoint will be constructed based on the cloud_provider and cloud_region
             parameters in the format "https://flink.{cloud_region}.{cloud_provider}.confluent.cloud".
@@ -197,8 +237,8 @@ def connect(  # noqa: PLR0913
             If your Kafka clusters / Flink tables require private networking, supply the base
             endpoint URL here (`"https://flink.us-east-2.aws.private.confluent.cloud"` for example,
             but cases and private networking technologies vary).
-        controlplane_endpoint: Base URL for the Confluent Cloud control plane (Tableflow and CMK
-            routes), distinct from the Flink gateway `endpoint`. Defaults to
+        controlplane_endpoint: Base URL for the Confluent Cloud control plane (Tableflow, Connect,
+            and CMK routes), distinct from the Flink gateway `endpoint`. Defaults to
             "https://api.confluent.cloud". A trailing slash is stripped if provided.
         dbname: Deprecated alias for database parameter (optional)
         result_page_fetch_pause_millis: Maximum milliseconds to wait between fetching pages of
@@ -268,6 +308,8 @@ def connect(  # noqa: PLR0913
         flink_api_secret=flink_api_secret,
         tableflow_api_key=tableflow_api_key,
         tableflow_api_secret=tableflow_api_secret,
+        connect_api_key=connect_api_key,
+        connect_api_secret=connect_api_secret,
         compute_pool_id=compute_pool_id,
         database=database or dbname,  # dbname is deprecated.
         database_kafka_cluster_id=database_kafka_cluster_id,
@@ -315,13 +357,19 @@ class Connection:
     _http_timeout_secs: float | None
 
     _controlplane_endpoint: str
-    """Base URL for the control plane (Tableflow, CMK), distinct from the Flink gateway."""
+    """Base URL for the control plane (Tableflow, Connect, CMK), distinct from the Flink gateway."""
     _controlplane_auth: tuple[str, str] | None
     """(key, secret) for Tableflow/control-plane routes, or None if no usable credential exists."""
+    _connect_auth: tuple[str, str] | None
+    """(key, secret) for Connect routes, or None if no usable credential exists."""
     _global_credentials: tuple[str, str] | None
     """(key, secret) of the global API key if one was supplied -- the only credential CMK takes."""
     _controlplane_client: httpx.Client | None
-    """Lazily created on first control-plane request; None until then."""
+    """Lazily created on first Tableflow control-plane request; None until then."""
+    _connect_controlplane_client: httpx.Client | None
+    """Lazily created on first Connect control-plane request; None until then."""
+    _connector_api: ConnectorApi | None
+    """Lazily composed on first connector method call; None until then."""
     _resolved_kafka_cluster_id: str | None
     """Cached `lkc-…` id for `database`; pre-seeded by database_kafka_cluster_id, else from CMK."""
 
@@ -342,6 +390,8 @@ class Connection:
         flink_api_secret: str | None = None,
         tableflow_api_key: str | None = None,
         tableflow_api_secret: str | None = None,
+        connect_api_key: str | None = None,
+        connect_api_secret: str | None = None,
         compute_pool_id: str | None = None,
         database: str | None = None,
         database_kafka_cluster_id: str | None = None,
@@ -365,6 +415,9 @@ class Connection:
             tableflow_api_key: API key for the Tableflow control-plane routes. Only consulted
                 when no global key is supplied. Must be supplied together with tableflow_api_secret.
             tableflow_api_secret: Secret paired with tableflow_api_key.
+            connect_api_key: API key for the Connect control-plane routes. Only consulted when no
+                global key is supplied. Must be supplied together with connect_api_secret.
+            connect_api_secret: Secret paired with connect_api_key.
             environment_id: Environment ID
             organization_id: Organization ID
             cloud_provider: Cloud provider (required if endpoint is not provided)
@@ -386,8 +439,8 @@ class Connection:
                 (optional). Pre-seeds the Tableflow cluster-id cache so the CMK lookup never
                 fires; otherwise the id is resolved lazily from `database` via CMK (needs a
                 global key).
-            controlplane_endpoint: Base URL for the control plane (Tableflow, CMK). Defaults to
-                "https://api.confluent.cloud". Trailing slash stripped if provided.
+            controlplane_endpoint: Base URL for the control plane (Tableflow, Connect, CMK).
+                Defaults to "https://api.confluent.cloud". Trailing slash stripped if provided.
             result_page_fetch_pause_millis: Milliseconds to possibly wait between fetching pages of
                 statement results. Defaults to 100ms. If most recent fetch of results for a
                 statement was more than this long ago, then no delay will happen when fetching
@@ -484,10 +537,15 @@ class Connection:
         self._controlplane_auth = _resolve_tableflow_credentials(
             global_api_key, global_api_secret, tableflow_api_key, tableflow_api_secret
         )
+        self._connect_auth = _resolve_connect_credentials(
+            global_api_key, global_api_secret, connect_api_key, connect_api_secret
+        )
         self._global_credentials = (
             (global_api_key, global_api_secret) if global_api_key and global_api_secret else None
         )
         self._controlplane_client = None
+        self._connect_controlplane_client = None
+        self._connector_api = None
         # A supplied cluster id pre-seeds the cache, so the CMK lookup never fires -- letting
         # Tableflow work with only a tableflow key pair (no global key needed for CMK).
         self._resolved_kafka_cluster_id = database_kafka_cluster_id or None
@@ -503,6 +561,8 @@ class Connection:
             self._client.close()
             if self._controlplane_client is not None:
                 self._controlplane_client.close()
+            if self._connect_controlplane_client is not None:
+                self._connect_controlplane_client.close()
         else:
             logger.info("Trying to close a closed connection, ignoring")
 
@@ -1550,8 +1610,27 @@ class Connection:
             # so callers see a DB-API OperationalError rather than a raw httpx exception leaking.
             raise OperationalError(f"error sending request: {e}") from e
 
+    def _make_controlplane_client(self, auth: tuple[str, str]) -> httpx.Client:
+        """Build a control-plane httpx client authenticated with the given (key, secret).
+
+        Shared by the Tableflow and Connect surfaces, which target the same control-plane host
+        but may carry distinct dedicated credentials when no global key is supplied.
+        """
+        key, secret = auth
+        client_kwargs: dict[str, Any] = {
+            "auth": httpx.BasicAuth(username=key, password=secret),
+            "base_url": self._controlplane_endpoint,
+            "headers": {
+                "Content-Type": "application/json",
+                "User-Agent": self._http_user_agent,
+            },
+        }
+        if self._http_timeout_secs is not None:
+            client_kwargs["timeout"] = self._http_timeout_secs
+        return httpx.Client(**client_kwargs)
+
     def _get_controlplane_client(self) -> httpx.Client:
-        """Return the control-plane httpx client, creating it on first use.
+        """Return the Tableflow control-plane httpx client, creating it on first use.
 
         Raises:
             InterfaceError: If the connection is closed.
@@ -1566,19 +1645,79 @@ class Connection:
                 "pair; neither was supplied to connect()."
             )
         if self._controlplane_client is None:
-            key, secret = self._controlplane_auth
-            client_kwargs: dict[str, Any] = {
-                "auth": httpx.BasicAuth(username=key, password=secret),
-                "base_url": self._controlplane_endpoint,
-                "headers": {
-                    "Content-Type": "application/json",
-                    "User-Agent": self._http_user_agent,
-                },
-            }
-            if self._http_timeout_secs is not None:
-                client_kwargs["timeout"] = self._http_timeout_secs
-            self._controlplane_client = httpx.Client(**client_kwargs)
+            self._controlplane_client = self._make_controlplane_client(self._controlplane_auth)
         return self._controlplane_client
+
+    def _get_connect_controlplane_client(self) -> httpx.Client:
+        """Return the Connect control-plane httpx client, creating it on first use.
+
+        Distinct from the Tableflow client: a dedicated connect_api_key (when no global key is
+        supplied) targets the Connect routes specifically.
+
+        Raises:
+            InterfaceError: If the connection is closed.
+            ProgrammingError: If no global key and no Connect key pair were supplied, so no
+                credential can authenticate the Connect routes.
+        """
+        if self._closed:
+            raise InterfaceError("Connection is closed")
+        if self._connect_auth is None:
+            raise ProgrammingError(
+                "Connectors require a global API key or a connect_api_key/connect_api_secret "
+                "pair; neither was supplied to connect()."
+            )
+        if self._connect_controlplane_client is None:
+            self._connect_controlplane_client = self._make_controlplane_client(self._connect_auth)
+        return self._connect_controlplane_client
+
+    def controlplane_request(
+        self, url, method="GET", raise_for_status=True, **kwargs
+    ) -> httpx.Response:
+        """Issue a Connect control-plane request -- satisfies ControlPlaneContext for ConnectorApi.
+
+        Routes through the connect-authed client, distinct from the Tableflow-authed
+        _controlplane_request. Same error shaping: an HTTP error status becomes OperationalError
+        carrying the status code, unless raise_for_status is False (ConnectorApi maps 404/409 to
+        its own exceptions).
+        """
+        return self._send_request(
+            self._get_connect_controlplane_client(), url, method, raise_for_status, **kwargs
+        )
+
+    def resolve_kafka_cluster_id(self) -> str:
+        """Public ControlPlaneContext hook -- delegates to the cached CMK resolution."""
+        return self._resolve_kafka_cluster_id()
+
+    def _get_connector_api(self) -> ConnectorApi:
+        """Return the ConnectorApi, composing it (with this Connection as context) on first use."""
+        if self._connector_api is None:
+            self._connector_api = ConnectorApi(self)
+        return self._connector_api
+
+    def create_connector(
+        self,
+        name: str,
+        *,
+        config: StrAnyDict,
+        wait_for_running: bool = True,
+        timeout: float = 300,
+    ) -> Connector:
+        """Create a managed connector; see ConnectorApi.create."""
+        return self._get_connector_api().create(
+            name, config=config, wait_for_running=wait_for_running, timeout=timeout
+        )
+
+    def get_connector(self, name: str) -> Connector:
+        """Read a connector's config and lifecycle state; see ConnectorApi.get."""
+        return self._get_connector_api().get(name)
+
+    def delete_connector(
+        self, name: str, *, wait_for_removal: bool = True, timeout: float = 300
+    ) -> None:
+        """Delete a connector; see ConnectorApi.delete."""
+        return self._get_connector_api().delete(
+            name, wait_for_removal=wait_for_removal, timeout=timeout
+        )
 
     _TABLEFLOW_TOPICS_PATH = "/tableflow/v1/tableflow-topics"
 

--- a/src/confluent_sql/connection.py
+++ b/src/confluent_sql/connection.py
@@ -330,7 +330,7 @@ class Connection:
     )
 
     _DEFAULT_CONTROLPLANE_ENDPOINT = "https://api.confluent.cloud"
-    """Control-plane host for Tableflow, Connect, and CMK routes -- distinct from the Flink gateway."""
+    """Control-plane host (Tableflow, Connect, CMK) -- distinct from the Flink gateway."""
 
     _TABLEFLOW_TOPICS_PATH = "/tableflow/v1/tableflow-topics"
     """Control-plane base path for the Tableflow-topics resource (enable/get/disable)."""

--- a/src/confluent_sql/connectors.py
+++ b/src/confluent_sql/connectors.py
@@ -270,7 +270,10 @@ class ConnectorApi:
         then repeated until RUNNING (raising on FAILED).
 
         Raises:
-            InterfaceError: If `config` lacks `connector.class` or its `name` disagrees with `name`.
+            InterfaceError: If `config` is missing a required key (`connector.class`,
+                `kafka.api.key`, `kafka.api.secret`) or its `name` disagrees with `name`.
+            ProgrammingError: If the context can't authenticate the Connect routes (no Connect
+                credential) or resolve the Kafka cluster id.
             ConnectorAlreadyExistsError: If a connector with this name exists (HTTP 409).
             OperationalError: On other API errors, on FAILED during a wait, or on wait timeout.
         """
@@ -301,6 +304,8 @@ class ConnectorApi:
         """Read a connector's config and lifecycle state, merging the base read with `/status`.
 
         Raises:
+            ProgrammingError: If the context can't authenticate the Connect routes (no Connect
+                credential) or resolve the Kafka cluster id.
             ConnectorNotFoundError: If no connector with this name exists (HTTP 404).
             OperationalError: On other API errors.
         """
@@ -311,6 +316,8 @@ class ConnectorApi:
         """Delete a connector and, by default, block until the base read 404s.
 
         Raises:
+            ProgrammingError: If the context can't authenticate the Connect routes (no Connect
+                credential) or resolve the Kafka cluster id.
             ConnectorNotFoundError: If no connector with this name exists (HTTP 404).
             OperationalError: On other API errors, or on wait timeout.
         """
@@ -332,7 +339,8 @@ class ConnectorApi:
             self._wait_for_removal(name, timeout)
 
     def _read_spec(self, name: str) -> ConnectorSpec:
-        """`GET .../connectors/{name}` -> parsed spec; 404 -> ConnectorNotFoundError."""
+        """`GET .../connectors/{name}` -> parsed spec; 404 -> ConnectorNotFoundError, other HTTP
+        errors -> OperationalError."""
         response = self._context.controlplane_request(
             f"{self._connectors_path()}/{name}", raise_for_status=False
         )
@@ -349,7 +357,8 @@ class ConnectorApi:
         return ConnectorSpec.from_response(response.json())
 
     def _fetch_status(self, name: str) -> ConnectorStatus:
-        """`GET .../connectors/{name}/status` -> parsed status; 404 -> ConnectorNotFoundError."""
+        """`GET .../connectors/{name}/status` -> parsed status; 404 -> ConnectorNotFoundError, other
+        HTTP errors -> OperationalError."""
         response = self._context.controlplane_request(
             f"{self._connectors_path()}/{name}/status", raise_for_status=False
         )

--- a/src/confluent_sql/connectors.py
+++ b/src/confluent_sql/connectors.py
@@ -1,0 +1,418 @@
+"""Connector types, request builders, response parsers, and lifecycle orchestration.
+
+These model the Connect v1 managed-connector API
+(`/connect/v1/environments/{env}/clusters/{lkc}/connectors`), which runs a Confluent-managed
+source or sink connector against the Kafka cluster backing a Flink database.
+
+Input vs. output, by design:
+
+- The only *request input* is the open-ended `config` map (`StrAnyDict`); there is no typed
+  request model, since the config is connector-class-specific. `build_create_payload` is the sole
+  request-side helper, validating and shaping that map.
+- Everything else here is an *output type* -- `Connector`, `ConnectorSpec`, `ConnectorStatus`,
+  `ConnectorState`, `TaskStatus`. Callers receive these from the API; they are not meant to be
+  constructed by hand (hence the `from_response` classmethods, not public constructors).
+- The one value that travels *both* directions is the `config` map itself: a caller passes it in
+  with plaintext secrets (e.g. `kafka.api.secret`), and it comes back on `ConnectorSpec.config`
+  with those same secrets redacted to `****` by the server. Same shape, different trust on each leg.
+
+The module is split into two layers plus a seam:
+
+- A pure, I/O-free layer -- the output models above, the `ConnectorState` enum, and
+  `build_create_payload`. Mirrors the `tableflow.py` precedent and is unit-testable with zero mocks.
+- An orchestration layer -- `ConnectorApi` -- holding the HTTP+poll choreography.
+- `ControlPlaneContext`, a narrow protocol `ConnectorApi` depends on instead of `Connection`, so
+  `connection` imports `connectors` and never the reverse.
+
+The Connect v1 wire shape splits what Tableflow kept together: a connector's lifecycle *state*
+(`connector.state`) is returned only by the `/status` sub-resource, never by the create response or
+the base read. So building a complete `Connector` always merges a config read with a status read.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Protocol
+
+import httpx
+
+from .exceptions import (
+    ConnectorAlreadyExistsError,
+    ConnectorNotFoundError,
+    InterfaceError,
+    OperationalError,
+)
+from .polling import sleep_with_backoff
+from .types import StrAnyDict
+
+_REQUIRED_CONFIG_KEYS = ("connector.class", "kafka.api.key", "kafka.api.secret")
+"""Config keys the Connect v1 create body marks required (besides `name`, which we inject)."""
+
+
+def build_create_payload(*, name: str, config: StrAnyDict) -> StrAnyDict:
+    """Assemble the `POST .../connectors` request body from the open-ended config map.
+
+    `config` is the connector-class-specific map. Beyond its class- and source/sink-specific keys
+    it must carry the keys the create body marks required: `connector.class` (the managed connector
+    plugin) plus the Kafka keypair `kafka.api.key` / `kafka.api.secret` the connector uses to reach
+    the cluster. These are validated here so an omission fails fast with a clear local error rather
+    than an opaque server 400. The wire also requires `config.name` to equal the top-level connector
+    name, so a missing `config.name` is filled in and a conflicting one is rejected rather than
+    silently overridden. The caller's `config` is not mutated.
+
+    Raises:
+        InterfaceError: If any required key (`connector.class`, `kafka.api.key`, `kafka.api.secret`)
+            is absent, or `config.name` is present and disagrees with `name`.
+    """
+    missing = [key for key in _REQUIRED_CONFIG_KEYS if key not in config]
+    if missing:
+        listed = ", ".join(f"'{key}'" for key in missing)
+        raise InterfaceError(f"connector config is missing required key(s): {listed}")
+    config_name = config.get("name")
+    if config_name is not None and config_name != name:
+        raise InterfaceError(
+            f"connector config 'name' ('{config_name}') does not match connector name '{name}'"
+        )
+    return {"name": name, "config": {**config, "name": name}}
+
+
+class ConnectorState(str, Enum):
+    """Lifecycle state of a connector (`/status` `connector.state`).
+
+    Output-only: appears on responses (`ConnectorStatus.state`, `Connector.state`) and drives the
+    create-wait; it is never an input. Extensible -- an unrecognized server-side value parses to
+    `UNKNOWN` rather than raising, so a future state doesn't break response parsing.
+    """
+
+    NONE = "NONE"
+    PROVISIONING = "PROVISIONING"
+    RUNNING = "RUNNING"
+    DEGRADED = "DEGRADED"
+    FAILED = "FAILED"
+    PAUSED = "PAUSED"
+    DELETED = "DELETED"
+    UNKNOWN = "UNKNOWN"
+
+    @classmethod
+    def _missing_(cls, value: object) -> ConnectorState:
+        return cls.UNKNOWN
+
+    @property
+    def is_terminal(self) -> bool:
+        """True once a create-wait can stop: the connector is healthy (RUNNING) or broken (FAILED).
+
+        PROVISIONING/NONE/DEGRADED are transient during provisioning; PAUSED/DELETED don't arise
+        from a create. UNKNOWN is deliberately non-terminal -- a state we don't understand
+        shouldn't end a wait; the caller's timeout governs that instead.
+        """
+        return self in (ConnectorState.RUNNING, ConnectorState.FAILED)
+
+
+@dataclass
+class TaskStatus:
+    """Per-task status from the `/status` response `tasks` array."""
+
+    id: int
+    state: str
+    worker_id: str | None
+    msg: str | None
+
+    @classmethod
+    def from_response(cls, data: StrAnyDict) -> TaskStatus:
+        return cls(
+            id=data["id"],
+            state=data["state"],
+            worker_id=data.get("worker_id"),
+            msg=data.get("msg"),
+        )
+
+
+@dataclass
+class ConnectorSpec:
+    """Parsed connector config read (`connect.v1.Connector`): config/tasks/type, never state.
+
+    The full `config` map is retained raw (it carries connector-class-specific keys and redacted
+    secrets); `connector_class` is the convenience read of `config['connector.class']`.
+    """
+
+    name: str
+    connector_class: str | None
+    type: str | None
+    config: StrAnyDict
+    tasks: list[StrAnyDict]
+    raw: StrAnyDict = field(repr=False)
+
+    @classmethod
+    def from_response(cls, data: StrAnyDict) -> ConnectorSpec:
+        try:
+            config = data["config"]
+            return cls(
+                name=data["name"],
+                connector_class=config.get("connector.class"),
+                type=data.get("type"),
+                config=config,
+                tasks=data.get("tasks") or [],
+                raw=data,
+            )
+        except KeyError as e:
+            raise OperationalError(f"Error parsing connector response, missing {e}.") from e
+
+
+@dataclass
+class ConnectorStatus:
+    """Parsed `/status` response -- the only source of the connector's lifecycle state."""
+
+    state: ConnectorState
+    worker_id: str | None
+    trace: str | None
+    tasks: list[TaskStatus]
+    plugin_lifecycle: str | None
+    raw: StrAnyDict = field(repr=False)
+
+    @classmethod
+    def from_response(cls, data: StrAnyDict) -> ConnectorStatus:
+        try:
+            connector = data["connector"]
+            return cls(
+                state=ConnectorState(connector.get("state")),
+                worker_id=connector.get("worker_id"),
+                trace=connector.get("trace") or None,
+                tasks=[TaskStatus.from_response(t) for t in (data.get("tasks") or [])],
+                plugin_lifecycle=data.get("plugin_lifecycle"),
+                raw=data,
+            )
+        except KeyError as e:
+            raise OperationalError(
+                f"Error parsing connector status response, missing {e}."
+            ) from e
+
+
+@dataclass
+class Connector:
+    """A connector assembled from its config read and its `/status` read.
+
+    Mirrors `TableflowTopic`: parsed `spec`/`status` and a `.state` convenience. The two halves
+    come from different endpoints because the Connect v1 wire never returns state on the connector
+    object itself. Holds no connection back-reference -- refresh via `Connection.get_connector`.
+    """
+
+    spec: ConnectorSpec
+    status: ConnectorStatus
+
+    @property
+    def state(self) -> ConnectorState:
+        """The connector's lifecycle state (convenience for `status.state`)."""
+        return self.status.state
+
+    @classmethod
+    def from_response(cls, read_data: StrAnyDict, status_data: StrAnyDict) -> Connector:
+        """Build a Connector from a config read body and a `/status` body."""
+        return cls(
+            spec=ConnectorSpec.from_response(read_data),
+            status=ConnectorStatus.from_response(status_data),
+        )
+
+
+class ControlPlaneContext(Protocol):
+    """The narrow surface `ConnectorApi` needs from its host connection.
+
+    Depending on this protocol rather than on `Connection` is what keeps the import graph acyclic
+    (`connection` imports `connectors`, never the reverse) and lets `ConnectorApi` be tested
+    against a tiny fake. The host supplies the environment, resolves the Kafka cluster id, and
+    issues authenticated control-plane requests; `ConnectorApi` owns everything connector-specific
+    on top.
+    """
+
+    environment_id: str
+
+    def resolve_kafka_cluster_id(self) -> str:
+        """Return the `lkc-…` id of the Kafka cluster the connectors run against."""
+        ...
+
+    def controlplane_request(
+        self, url: str, method: str = "GET", raise_for_status: bool = True, **kwargs: object
+    ) -> httpx.Response:
+        """Issue a request against the connector control-plane routes, authed for Connect."""
+        ...
+
+
+class ConnectorApi:
+    """Create / read / delete choreography for managed connectors against the Connect v1 API.
+
+    Holds the stateful HTTP + polling work behind `Connection`'s flat passthroughs. Blocks by
+    default per the repo's `wait_for_<settled-state>` convention, polling via `sleep_with_backoff`.
+    Because the wire returns lifecycle state only from the `/status` sub-resource, a complete
+    `Connector` always pairs a config read with a status read.
+    """
+
+    def __init__(self, context: ControlPlaneContext) -> None:
+        self._context = context
+
+    def _connectors_path(self) -> str:
+        """The base `/connect/v1/.../connectors` collection path for this connection's cluster."""
+        env = self._context.environment_id
+        cluster = self._context.resolve_kafka_cluster_id()
+        return f"/connect/v1/environments/{env}/clusters/{cluster}/connectors"
+
+    def create(
+        self,
+        name: str,
+        *,
+        config: StrAnyDict,
+        wait_for_running: bool = True,
+        timeout: float = 300,
+    ) -> Connector:
+        """Create a managed connector and, by default, block until it reaches RUNNING.
+
+        `POST .../connectors`. The create response carries the config but no lifecycle state, so a
+        single `/status` read always follows to populate it; with `wait_for_running` that read is
+        then repeated until RUNNING (raising on FAILED).
+
+        Raises:
+            InterfaceError: If `config` lacks `connector.class` or its `name` disagrees with `name`.
+            ConnectorAlreadyExistsError: If a connector with this name exists (HTTP 409).
+            OperationalError: On other API errors, on FAILED during a wait, or on wait timeout.
+        """
+        payload = build_create_payload(name=name, config=config)
+        response = self._context.controlplane_request(
+            self._connectors_path(), method="POST", json=payload, raise_for_status=False
+        )
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 409:
+                raise ConnectorAlreadyExistsError(
+                    f"Connector '{name}' already exists", connector_name=name
+                ) from e
+            raise OperationalError(
+                "Error creating connector", http_status_code=e.response.status_code
+            ) from e
+
+        connector = Connector(
+            spec=ConnectorSpec.from_response(response.json()),
+            status=self._fetch_status(name),
+        )
+        if wait_for_running:
+            return self._wait_for_running(connector, timeout)
+        return connector
+
+    def get(self, name: str) -> Connector:
+        """Read a connector's config and lifecycle state, merging the base read with `/status`.
+
+        Raises:
+            ConnectorNotFoundError: If no connector with this name exists (HTTP 404).
+            OperationalError: On other API errors.
+        """
+        spec = self._read_spec(name)
+        return Connector(spec=spec, status=self._fetch_status(name))
+
+    def delete(self, name: str, *, wait_for_removal: bool = True, timeout: float = 300) -> None:
+        """Delete a connector and, by default, block until the base read 404s.
+
+        Raises:
+            ConnectorNotFoundError: If no connector with this name exists (HTTP 404).
+            OperationalError: On other API errors, or on wait timeout.
+        """
+        response = self._context.controlplane_request(
+            f"{self._connectors_path()}/{name}", method="DELETE", raise_for_status=False
+        )
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ConnectorNotFoundError(
+                    f"Connector '{name}' does not exist", connector_name=name
+                ) from e
+            raise OperationalError(
+                "Error deleting connector", http_status_code=e.response.status_code
+            ) from e
+
+        if wait_for_removal:
+            self._wait_for_removal(name, timeout)
+
+    def _read_spec(self, name: str) -> ConnectorSpec:
+        """`GET .../connectors/{name}` -> parsed spec; 404 -> ConnectorNotFoundError."""
+        response = self._context.controlplane_request(
+            f"{self._connectors_path()}/{name}", raise_for_status=False
+        )
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ConnectorNotFoundError(
+                    f"Connector '{name}' does not exist", connector_name=name
+                ) from e
+            raise OperationalError(
+                "Error reading connector", http_status_code=e.response.status_code
+            ) from e
+        return ConnectorSpec.from_response(response.json())
+
+    def _fetch_status(self, name: str) -> ConnectorStatus:
+        """`GET .../connectors/{name}/status` -> parsed status; 404 -> ConnectorNotFoundError."""
+        response = self._context.controlplane_request(
+            f"{self._connectors_path()}/{name}/status", raise_for_status=False
+        )
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ConnectorNotFoundError(
+                    f"Connector '{name}' does not exist", connector_name=name
+                ) from e
+            raise OperationalError(
+                "Error reading connector status", http_status_code=e.response.status_code
+            ) from e
+        return ConnectorStatus.from_response(response.json())
+
+    def _wait_for_running(self, connector: Connector, timeout: float) -> Connector:
+        """Poll `/status` until the connector reaches RUNNING, refreshing only its status.
+
+        The spec is fixed once created, so each poll rebuilds the `Connector` from the original spec
+        and the freshly-read status rather than re-reading the config.
+
+        Raises:
+            OperationalError: If the connector transitions to FAILED (surfacing `connector.trace`),
+                or if RUNNING is not reached within timeout.
+        """
+        def raise_if_failed(candidate: Connector) -> None:
+            if candidate.state is ConnectorState.FAILED:
+                detail = candidate.status.trace or ""
+                raise OperationalError(
+                    f"Connector '{candidate.spec.name}' transitioned to FAILED: {detail}".strip()
+                )
+
+        raise_if_failed(connector)
+        if connector.state is ConnectorState.RUNNING:
+            return connector
+
+        for _ in sleep_with_backoff(timeout):
+            connector = Connector(
+                spec=connector.spec, status=self._fetch_status(connector.spec.name)
+            )
+            raise_if_failed(connector)
+            if connector.state is ConnectorState.RUNNING:
+                return connector
+
+        raise OperationalError(
+            f"Connector '{connector.spec.name}' did not reach RUNNING within {timeout} seconds"
+        )
+
+    def _wait_for_removal(self, name: str, timeout: float) -> None:
+        """Poll the base read until it 404s, confirming the connector is gone.
+
+        Raises:
+            OperationalError: If the connector is not removed within timeout.
+        """
+        try:
+            self._read_spec(name)
+        except ConnectorNotFoundError:
+            return
+
+        for _ in sleep_with_backoff(timeout):
+            try:
+                self._read_spec(name)
+            except ConnectorNotFoundError:
+                return
+
+        raise OperationalError(f"Connector '{name}' was not removed within {timeout} seconds")

--- a/src/confluent_sql/exceptions.py
+++ b/src/confluent_sql/exceptions.py
@@ -232,6 +232,38 @@ class TableflowTopicAlreadyExistsError(OperationalError):
         self.table_name = table_name
 
 
+class ConnectorNotFoundError(OperationalError):
+    """
+    Exception raised when a connector does not exist.
+
+    Raised on an HTTP 404 from get_connector() or delete_connector() -- i.e. the connector was
+    never created (or has already been removed). delete_connector(wait_for_removal=True) polls
+    against this 404 to confirm teardown.
+
+    Attributes:
+        connector_name: The name of the connector that was not found.
+    """
+
+    def __init__(self, message: str, connector_name: str):
+        super().__init__(message)
+        self.connector_name = connector_name
+
+
+class ConnectorAlreadyExistsError(OperationalError):
+    """
+    Exception raised when creating a connector whose name is already taken.
+
+    Raised on an HTTP 409 from create_connector().
+
+    Attributes:
+        connector_name: The name of the connector that already existed.
+    """
+
+    def __init__(self, message: str, connector_name: str):
+        super().__init__(message)
+        self.connector_name = connector_name
+
+
 class IntegrityError(DatabaseError):
     """
     Exception raised when the relational integrity of the database is affected.

--- a/tests/integration/test_connector.py
+++ b/tests/integration/test_connector.py
@@ -1,0 +1,162 @@
+"""Integration test for the connector lifecycle: create -> wait RUNNING -> delete, end to end.
+
+Runs only when a connector-capable configuration is present in the environment. Uses a managed
+**Datagen source** connector -- free, self-contained, and needing no external system to stand up.
+"Green" here is a health check (state RUNNING), not a data read-back. The connector produces to its
+own Kafka topic, which connector deletion does not remove; teardown makes a best-effort attempt to
+drop it via the Flink table abstraction.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Generator
+from datetime import datetime
+
+import pytest
+
+import confluent_sql
+from confluent_sql import ConnectorState
+from confluent_sql.connection import Connection
+
+
+def _connector_connection_from_env() -> Connection:
+    """Build a connector-capable Connection from env, or skip if the configuration is incomplete.
+
+    Beyond the standard Flink/environment vars, connectors need a control-plane credential (a global
+    key covers it, else CONFLUENT_CONNECT_API_KEY/SECRET) and a way to know the cluster id (a global
+    key resolves it via CMK, else CONFLUENT_DATABASE_KAFKA_CLUSTER_ID supplies it directly). The
+    Datagen connector additionally needs its own Kafka API key pair to produce to the topic.
+    """
+    global_api_key = os.getenv("CONFLUENT_GLOBAL_API_KEY", "")
+    global_api_secret = os.getenv("CONFLUENT_GLOBAL_API_SECRET", "")
+    flink_api_key = os.getenv("CONFLUENT_FLINK_API_KEY", "")
+    flink_api_secret = os.getenv("CONFLUENT_FLINK_API_SECRET", "")
+    connect_api_key = os.getenv("CONFLUENT_CONNECT_API_KEY", "")
+    connect_api_secret = os.getenv("CONFLUENT_CONNECT_API_SECRET", "")
+    environment_id = os.getenv("CONFLUENT_ENV_ID", "")
+    organization_id = os.getenv("CONFLUENT_ORG_ID", "")
+    cloud_provider = os.getenv("CONFLUENT_CLOUD_PROVIDER", "")
+    cloud_region = os.getenv("CONFLUENT_CLOUD_REGION", "")
+    database = os.getenv("CONFLUENT_TEST_DBNAME", "")
+    database_kafka_cluster_id = os.getenv("CONFLUENT_DATABASE_KAFKA_CLUSTER_ID", "")
+    compute_pool_id = os.getenv("CONFLUENT_COMPUTE_POOL_ID", "")
+
+    has_global = bool(global_api_key) and bool(global_api_secret)
+    has_flink = bool(flink_api_key) and bool(flink_api_secret)
+    has_connect = bool(connect_api_key) and bool(connect_api_secret)
+    # A half-supplied pair (key without secret, or vice versa) would make connect() raise
+    # InterfaceError; treat that as "not configured" and skip rather than erroring at setup.
+    no_half_pairs = not (
+        bool(global_api_key) != bool(global_api_secret)
+        or bool(flink_api_key) != bool(flink_api_secret)
+        or bool(connect_api_key) != bool(connect_api_secret)
+    )
+    # The connection's own (Flink) client needs a global or Flink-region pair.
+    flink_auth_ok = has_global or has_flink
+    # Control-plane credential: a global key, or a dedicated connect pair.
+    controlplane_ok = has_global or has_connect
+    # Cluster id obtainable: a global key (CMK lookup), or a directly-supplied id.
+    cluster_ok = has_global or bool(database_kafka_cluster_id)
+    base_ok = all([environment_id, organization_id, cloud_provider, cloud_region, database])
+    if not (no_half_pairs and flink_auth_ok and controlplane_ok and cluster_ok and base_ok):
+        pytest.skip("Missing environment variables for a connector-capable integration connection")
+
+    return confluent_sql.connect(
+        global_api_key=global_api_key,
+        global_api_secret=global_api_secret,
+        flink_api_key=flink_api_key,
+        flink_api_secret=flink_api_secret,
+        connect_api_key=connect_api_key,
+        connect_api_secret=connect_api_secret,
+        environment_id=environment_id,
+        organization_id=organization_id,
+        compute_pool_id=compute_pool_id,
+        cloud_provider=cloud_provider,
+        cloud_region=cloud_region,
+        database=database,
+        database_kafka_cluster_id=database_kafka_cluster_id or None,
+    )
+
+
+def _connector_kafka_credentials() -> tuple[str, str]:
+    """The Datagen connector's own Kafka API key pair, or skip if absent."""
+    key = os.getenv("CONFLUENT_CONNECTOR_KAFKA_API_KEY", "")
+    secret = os.getenv("CONFLUENT_CONNECTOR_KAFKA_API_SECRET", "")
+    if not (key and secret):
+        pytest.skip(
+            "Missing CONFLUENT_CONNECTOR_KAFKA_API_KEY/SECRET for the Datagen connector's producer"
+        )
+    return key, secret
+
+
+@pytest.fixture()
+def connector_connection(load_env_file) -> Generator[Connection, None, None]:
+    """A connector-capable connection for the arc test, closed at the end of the test."""
+    conn = _connector_connection_from_env()
+    yield conn
+    conn.close()
+
+
+@pytest.fixture()
+def connector_names(
+    connector_connection: Connection, filtered_username: str
+) -> Generator[tuple[str, str], None, None]:
+    """A unique (connector_name, topic_name) pair; the topic is best-effort dropped on teardown.
+
+    Depends on connector_connection so it tears down first (reverse setup order), keeping the
+    connection alive for the topic cleanup.
+    """
+    stamp = f"{filtered_username}_{datetime.now():%Y%m%d_%H%M%S}"
+    connector_name = f"confluentsql_pytest_connector_{stamp}"
+    topic_name = f"confluentsql_pytest_topic_{stamp}"
+    yield connector_name, topic_name
+    # Connector deletion leaves its target topic behind; drop it via the Flink table abstraction.
+    with connector_connection.closing_cursor() as cursor:
+        try:
+            cursor.execute(f"DROP TABLE IF EXISTS `{topic_name}`")
+        except Exception as e:
+            print(f"Error dropping topic {topic_name} during teardown: {e}")
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+class TestConnectorLifecycle:
+    """End-to-end arc: create Datagen source -> wait RUNNING -> assert healthy -> delete -> gone."""
+
+    def test_create_check_delete_arc(
+        self,
+        connector_connection: Connection,
+        connector_names: tuple[str, str],
+    ) -> None:
+        conn = connector_connection
+        connector_name, topic_name = connector_names
+        kafka_api_key, kafka_api_secret = _connector_kafka_credentials()
+
+        config = {
+            "connector.class": "DatagenSource",
+            "kafka.api.key": kafka_api_key,
+            "kafka.api.secret": kafka_api_secret,
+            "kafka.topic": topic_name,
+            "output.data.format": "JSON",
+            "quickstart": "ORDERS",
+            "tasks.max": "1",
+        }
+
+        connector_created = False
+        try:
+            connector = conn.create_connector(
+                connector_name, config=config, wait_for_running=True, timeout=600
+            )
+            connector_created = True
+            assert connector.state is ConnectorState.RUNNING
+            assert connector.spec.connector_class == "DatagenSource"
+
+            # Re-read independently: the config-read + /status-read merge stays healthy.
+            refreshed = conn.get_connector(connector_name)
+            assert refreshed.state is ConnectorState.RUNNING
+        finally:
+            if connector_created:
+                conn.delete_connector(connector_name, wait_for_removal=True, timeout=600)
+                with pytest.raises(confluent_sql.ConnectorNotFoundError):
+                    conn.get_connector(connector_name)

--- a/tests/unit/test_connection_connector_unit.py
+++ b/tests/unit/test_connection_connector_unit.py
@@ -1,0 +1,165 @@
+"""Unit tests for the Connection-level connector plumbing: credentials, client, and passthroughs."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import Mock
+
+import httpx
+import pytest
+
+from confluent_sql import InterfaceError, OperationalError, ProgrammingError
+from confluent_sql.connection import Connection, _resolve_connect_credentials, connect
+
+pytestmark = pytest.mark.unit
+
+
+def _connect(**overrides: Any) -> Connection:
+    """Build a Connection with an explicit endpoint and deterministic (non-env) credentials."""
+    kwargs: dict[str, Any] = {
+        "flink_api_key": "flink-k",
+        "flink_api_secret": "flink-s",
+        "global_api_key": "",
+        "global_api_secret": "",
+        "connect_api_key": "",
+        "connect_api_secret": "",
+        "environment_id": "env-1",
+        "organization_id": "org-1",
+        "endpoint": "https://flink.example.com",
+        "database": "",
+    }
+    kwargs.update(overrides)
+    return connect(**kwargs)
+
+
+class TestResolveConnectCredentials:
+    """The Connect control-plane credential pick: global wins, else the connect pair, else None."""
+
+    def test_global_wins_over_connect(self) -> None:
+        assert _resolve_connect_credentials("gk", "gs", "ck", "cs") == ("gk", "gs")
+
+    def test_connect_pair_when_no_global(self) -> None:
+        assert _resolve_connect_credentials("", "", "ck", "cs") == ("ck", "cs")
+
+    def test_none_when_neither(self) -> None:
+        assert _resolve_connect_credentials("", "", "", "") is None
+
+    def test_half_connect_pair_raises(self) -> None:
+        with pytest.raises(InterfaceError, match="connect_api_key and connect_api_secret"):
+            _resolve_connect_credentials("", "", "ck", "")
+
+    def test_global_short_circuits_half_connect_pair(self) -> None:
+        assert _resolve_connect_credentials("gk", "gs", "ck", "") == ("gk", "gs")
+
+
+class TestConnectControlplaneClient:
+    """The connect-authed control-plane client is distinct from the Tableflow one."""
+
+    def test_no_connect_credentials_raises(self) -> None:
+        conn = _connect()  # flink-only creds
+        with pytest.raises(ProgrammingError, match="connect_api_key"):
+            conn._get_connect_controlplane_client()
+
+    def test_connect_pair_authenticates(self, mocker) -> None:
+        spy = mocker.patch("confluent_sql.connection.httpx.BasicAuth", wraps=httpx.BasicAuth)
+        conn = _connect(connect_api_key="ck", connect_api_secret="cs")
+        client = conn._get_connect_controlplane_client()
+        assert str(client.base_url) == "https://api.confluent.cloud"
+        spy.assert_called_with(username="ck", password="cs")
+
+    def test_distinct_from_tableflow_client_with_different_creds(self) -> None:
+        conn = _connect(
+            tableflow_api_key="tk",
+            tableflow_api_secret="ts",
+            connect_api_key="ck",
+            connect_api_secret="cs",
+        )
+        assert conn._get_connect_controlplane_client() is not conn._get_controlplane_client()
+
+    def test_connect_client_cached(self) -> None:
+        conn = _connect(connect_api_key="ck", connect_api_secret="cs")
+        assert conn._get_connect_controlplane_client() is conn._get_connect_controlplane_client()
+
+    def test_close_closes_created_connect_client(self) -> None:
+        conn = _connect(connect_api_key="ck", connect_api_secret="cs")
+        client = conn._get_connect_controlplane_client()
+        conn.close()
+        assert client.is_closed
+
+    def test_closed_connection_raises(self) -> None:
+        conn = _connect(connect_api_key="ck", connect_api_secret="cs")
+        conn.close()
+        with pytest.raises(InterfaceError, match="Connection is closed"):
+            conn._get_connect_controlplane_client()
+
+
+class TestControlPlaneContextSatisfaction:
+    """Connection satisfies the ControlPlaneContext protocol ConnectorApi depends on."""
+
+    def test_resolve_kafka_cluster_id_delegates(self) -> None:
+        conn = _connect(database_kafka_cluster_id="lkc-9")
+        assert conn.resolve_kafka_cluster_id() == "lkc-9"
+
+    def test_controlplane_request_routes_through_connect_client(self) -> None:
+        conn = _connect(connect_api_key="ck", connect_api_secret="cs")
+        client = Mock()
+        client.request = Mock(return_value=Mock(content=b"{}"))
+        conn._get_connect_controlplane_client = Mock(return_value=client)  # type: ignore[method-assign]
+        conn.controlplane_request("/x", method="POST", json={"a": 1}, raise_for_status=False)
+        client.request.assert_called_once_with("POST", "/x", json={"a": 1})
+
+    def test_controlplane_request_http_error_becomes_operational(self) -> None:
+        conn = _connect(connect_api_key="ck", connect_api_secret="cs")
+        response = Mock()
+        inner = Mock()
+        inner.status_code = 500
+        response.raise_for_status = Mock(
+            side_effect=httpx.HTTPStatusError("boom", request=Mock(), response=inner)
+        )
+        client = Mock()
+        client.request = Mock(return_value=response)
+        conn._get_connect_controlplane_client = Mock(return_value=client)  # type: ignore[method-assign]
+        with pytest.raises(OperationalError):
+            conn.controlplane_request("/x")
+
+
+class TestConnectorPassthroughs:
+    """The three Connection methods are one-line delegations to a lazily-composed ConnectorApi."""
+
+    def test_create_connector_delegates(self) -> None:
+        conn = _connect(connect_api_key="ck", connect_api_secret="cs")
+        api = Mock()
+        conn._connector_api = api
+        config = {"connector.class": "DatagenSource"}
+
+        result = conn.create_connector("c1", config=config, wait_for_running=False, timeout=10)
+
+        api.create.assert_called_once_with(
+            "c1", config=config, wait_for_running=False, timeout=10
+        )
+        assert result is api.create.return_value
+
+    def test_get_connector_delegates(self) -> None:
+        conn = _connect(connect_api_key="ck", connect_api_secret="cs")
+        api = Mock()
+        conn._connector_api = api
+
+        result = conn.get_connector("c1")
+
+        api.get.assert_called_once_with("c1")
+        assert result is api.get.return_value
+
+    def test_delete_connector_delegates(self) -> None:
+        conn = _connect(connect_api_key="ck", connect_api_secret="cs")
+        api = Mock()
+        conn._connector_api = api
+
+        conn.delete_connector("c1", wait_for_removal=False, timeout=10)
+
+        api.delete.assert_called_once_with("c1", wait_for_removal=False, timeout=10)
+
+    def test_connector_api_lazily_composed_with_self_as_context(self) -> None:
+        conn = _connect(connect_api_key="ck", connect_api_secret="cs")
+        first = conn._get_connector_api()
+        assert first is conn._get_connector_api()
+        assert first._context is conn

--- a/tests/unit/test_connectors_connection_unit.py
+++ b/tests/unit/test_connectors_connection_unit.py
@@ -1,0 +1,341 @@
+"""Unit tests for ConnectorApi, driven against a fake ControlPlaneContext (no httpx, no network)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import Mock
+
+import httpx
+import pytest
+
+from confluent_sql.connectors import ConnectorApi, ConnectorState
+from confluent_sql.exceptions import (
+    ConnectorAlreadyExistsError,
+    ConnectorNotFoundError,
+    OperationalError,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _ok_response(body: dict | None = None, status_code: int = 200) -> Mock:
+    """A success response whose raise_for_status() is a no-op and .json() returns body."""
+    response = Mock()
+    response.status_code = status_code
+    response.raise_for_status = Mock()
+    response.json = Mock(return_value=body or {})
+    return response
+
+
+def _error_response(status_code: int) -> Mock:
+    """A response whose raise_for_status() raises an HTTPStatusError of the given code."""
+    response = Mock()
+    response.status_code = status_code
+    inner = Mock()
+    inner.status_code = status_code
+    response.raise_for_status = Mock(
+        side_effect=httpx.HTTPStatusError("boom", request=Mock(), response=inner)
+    )
+    return response
+
+
+def _create_config() -> dict:
+    """A config carrying the keys build_create_payload requires; details are irrelevant here."""
+    return {
+        "connector.class": "DatagenSource",
+        "kafka.api.key": "K",
+        "kafka.api.secret": "S",
+    }
+
+
+def _read_body() -> dict:
+    return {
+        "name": "MyDatagen",
+        "config": {"connector.class": "DatagenSource", "name": "MyDatagen"},
+        "tasks": [],
+        "type": "source",
+    }
+
+
+def _status_body(state: str, trace: str = "") -> dict:
+    return {
+        "name": "MyDatagen",
+        "type": "source",
+        "connector": {"state": state, "worker_id": "w-1", "trace": trace},
+        "tasks": [],
+    }
+
+
+class FakeControlPlane:
+    """A ~20-line stand-in satisfying ControlPlaneContext, routing by HTTP method / `/status` path.
+
+    Responses are queued per logical operation (create/read/status/delete) and popped in order, so
+    a test can script a state transition by queueing several `status` responses.
+    """
+
+    environment_id = "env-123"
+
+    def __init__(self) -> None:
+        self._queues: dict[str, list[Mock]] = {
+            "create": [],
+            "read": [],
+            "status": [],
+            "delete": [],
+        }
+        self.requests: list[tuple[str, str]] = []
+
+    def resolve_kafka_cluster_id(self) -> str:
+        return "lkc-abc"
+
+    def queue(self, key: str, *responses: Mock) -> None:
+        self._queues[key].extend(responses)
+
+    def controlplane_request(
+        self, url: str, method: str = "GET", raise_for_status: bool = True, **kwargs: Any
+    ) -> Mock:
+        self.requests.append((method, url))
+        if method == "POST":
+            key = "create"
+        elif method == "DELETE":
+            key = "delete"
+        elif url.endswith("/status"):
+            key = "status"
+        else:
+            key = "read"
+        queue = self._queues[key]
+        if not queue:
+            raise AssertionError(f"Wacky -- no queued {key} response for {method} {url}")
+        return queue.pop(0)
+
+    def count(self, key: str) -> int:
+        method = {"create": "POST", "delete": "DELETE"}.get(key)
+        if key == "status":
+            return sum(1 for m, u in self.requests if m == "GET" and u.endswith("/status"))
+        if key == "read":
+            return sum(1 for m, u in self.requests if m == "GET" and not u.endswith("/status"))
+        return sum(1 for m, _ in self.requests if m == method)
+
+
+@pytest.fixture()
+def no_sleep(mocker):
+    """Neutralize backoff pacing so wait loops iterate instantly; yields up to 20 times."""
+    return mocker.patch(
+        "confluent_sql.connectors.sleep_with_backoff", return_value=iter([None] * 20)
+    )
+
+
+class TestConnectorApiCreate:
+    """create() POSTs, then reads /status -- always once, looping only when waiting."""
+
+    def test_blocks_until_running(self, no_sleep) -> None:
+        ctx = FakeControlPlane()
+        ctx.queue("create", _ok_response(_read_body(), status_code=201))
+        ctx.queue(
+            "status",
+            _ok_response(_status_body("PROVISIONING")),
+            _ok_response(_status_body("RUNNING")),
+        )
+        api = ConnectorApi(ctx)
+
+        connector = api.create("MyDatagen", config=_create_config())
+
+        assert connector.state is ConnectorState.RUNNING
+        assert ctx.count("status") == 2
+
+    def test_wait_false_does_exactly_one_status_read(self, no_sleep) -> None:
+        ctx = FakeControlPlane()
+        ctx.queue("create", _ok_response(_read_body(), status_code=201))
+        ctx.queue("status", _ok_response(_status_body("PROVISIONING")))
+        api = ConnectorApi(ctx)
+
+        connector = api.create(
+            "MyDatagen", config=_create_config(), wait_for_running=False
+        )
+
+        assert connector.state is ConnectorState.PROVISIONING
+        assert ctx.count("status") == 1
+        no_sleep.assert_not_called()
+
+    def test_already_running_returns_without_polling(self, no_sleep) -> None:
+        ctx = FakeControlPlane()
+        ctx.queue("create", _ok_response(_read_body(), status_code=201))
+        ctx.queue("status", _ok_response(_status_body("RUNNING")))
+        api = ConnectorApi(ctx)
+
+        connector = api.create("MyDatagen", config=_create_config())
+
+        assert connector.state is ConnectorState.RUNNING
+        assert ctx.count("status") == 1
+        no_sleep.assert_not_called()
+
+    def test_generic_error_raises_operational_not_already_exists(self) -> None:
+        ctx = FakeControlPlane()
+        ctx.queue("create", _error_response(500))
+        api = ConnectorApi(ctx)
+
+        with pytest.raises(OperationalError) as exc:
+            api.create("MyDatagen", config=_create_config())
+        assert not isinstance(exc.value, ConnectorAlreadyExistsError)
+        assert exc.value.http_status_code == 500
+
+    def test_409_raises_already_exists(self) -> None:
+        ctx = FakeControlPlane()
+        ctx.queue("create", _error_response(409))
+        api = ConnectorApi(ctx)
+
+        with pytest.raises(ConnectorAlreadyExistsError) as exc:
+            api.create("MyDatagen", config=_create_config())
+        assert exc.value.connector_name == "MyDatagen"
+
+    def test_failed_state_raises_with_trace(self, no_sleep) -> None:
+        ctx = FakeControlPlane()
+        ctx.queue("create", _ok_response(_read_body(), status_code=201))
+        ctx.queue(
+            "status",
+            _ok_response(_status_body("FAILED", trace="java.lang.RuntimeException: nope")),
+        )
+        api = ConnectorApi(ctx)
+
+        with pytest.raises(OperationalError, match="java.lang.RuntimeException: nope"):
+            api.create("MyDatagen", config=_create_config())
+
+    def test_timeout_raises(self, mocker) -> None:
+        mocker.patch("confluent_sql.connectors.sleep_with_backoff", return_value=iter([]))
+        ctx = FakeControlPlane()
+        ctx.queue("create", _ok_response(_read_body(), status_code=201))
+        ctx.queue("status", _ok_response(_status_body("PROVISIONING")))
+        api = ConnectorApi(ctx)
+
+        with pytest.raises(OperationalError, match="did not reach RUNNING"):
+            api.create("MyDatagen", config=_create_config(), timeout=5)
+
+
+class TestConnectorApiGet:
+    """get() merges the config read and the /status read."""
+
+    def test_merges_read_and_status(self) -> None:
+        ctx = FakeControlPlane()
+        ctx.queue("read", _ok_response(_read_body()))
+        ctx.queue("status", _ok_response(_status_body("RUNNING")))
+        api = ConnectorApi(ctx)
+
+        connector = api.get("MyDatagen")
+
+        assert connector.spec.connector_class == "DatagenSource"
+        assert connector.state is ConnectorState.RUNNING
+
+    def test_path_carries_env_cluster_and_name(self) -> None:
+        ctx = FakeControlPlane()
+        ctx.queue("read", _ok_response(_read_body()))
+        ctx.queue("status", _ok_response(_status_body("RUNNING")))
+        api = ConnectorApi(ctx)
+
+        api.get("MyDatagen")
+
+        read_url = next(u for m, u in ctx.requests if m == "GET" and not u.endswith("/status"))
+        assert read_url == (
+            "/connect/v1/environments/env-123/clusters/lkc-abc/connectors/MyDatagen"
+        )
+
+    def test_404_raises_not_found_without_status_call(self) -> None:
+        ctx = FakeControlPlane()
+        ctx.queue("read", _error_response(404))
+        api = ConnectorApi(ctx)
+
+        with pytest.raises(ConnectorNotFoundError) as exc:
+            api.get("MyDatagen")
+        assert exc.value.connector_name == "MyDatagen"
+        assert ctx.count("status") == 0
+
+    def test_generic_read_error_raises_operational(self) -> None:
+        ctx = FakeControlPlane()
+        ctx.queue("read", _error_response(500))
+        api = ConnectorApi(ctx)
+
+        with pytest.raises(OperationalError) as exc:
+            api.get("MyDatagen")
+        assert exc.value.http_status_code == 500
+
+    def test_status_404_after_successful_read_raises_not_found(self) -> None:
+        # A connector deleted between the base read and the /status read: status 404s.
+        ctx = FakeControlPlane()
+        ctx.queue("read", _ok_response(_read_body()))
+        ctx.queue("status", _error_response(404))
+        api = ConnectorApi(ctx)
+
+        with pytest.raises(ConnectorNotFoundError) as exc:
+            api.get("MyDatagen")
+        assert exc.value.connector_name == "MyDatagen"
+
+    def test_generic_status_error_raises_operational(self) -> None:
+        ctx = FakeControlPlane()
+        ctx.queue("read", _ok_response(_read_body()))
+        ctx.queue("status", _error_response(500))
+        api = ConnectorApi(ctx)
+
+        with pytest.raises(OperationalError) as exc:
+            api.get("MyDatagen")
+        assert exc.value.http_status_code == 500
+
+
+class TestConnectorApiDelete:
+    """delete() DELETEs, then polls the base read until it 404s."""
+
+    def test_blocks_until_gone(self, no_sleep) -> None:
+        ctx = FakeControlPlane()
+        ctx.queue("delete", _ok_response())
+        ctx.queue("read", _error_response(404))
+        api = ConnectorApi(ctx)
+
+        assert api.delete("MyDatagen") is None
+        assert ctx.count("read") == 1
+
+    def test_404_raises_not_found(self) -> None:
+        ctx = FakeControlPlane()
+        ctx.queue("delete", _error_response(404))
+        api = ConnectorApi(ctx)
+
+        with pytest.raises(ConnectorNotFoundError) as exc:
+            api.delete("MyDatagen")
+        assert exc.value.connector_name == "MyDatagen"
+
+    def test_generic_error_raises_operational(self) -> None:
+        ctx = FakeControlPlane()
+        ctx.queue("delete", _error_response(500))
+        api = ConnectorApi(ctx)
+
+        with pytest.raises(OperationalError) as exc:
+            api.delete("MyDatagen")
+        assert exc.value.http_status_code == 500
+
+    def test_polls_through_a_still_present_read_until_gone(self, no_sleep) -> None:
+        # The connector is still readable on the first poll, then 404s on the second.
+        ctx = FakeControlPlane()
+        ctx.queue("delete", _ok_response())
+        ctx.queue("read", _ok_response(_read_body()), _error_response(404))
+        api = ConnectorApi(ctx)
+
+        api.delete("MyDatagen")
+
+        assert ctx.count("read") == 2
+
+    def test_wait_false_skips_polling(self, no_sleep) -> None:
+        ctx = FakeControlPlane()
+        ctx.queue("delete", _ok_response())
+        api = ConnectorApi(ctx)
+
+        api.delete("MyDatagen", wait_for_removal=False)
+
+        assert ctx.count("read") == 0
+        no_sleep.assert_not_called()
+
+    def test_removal_timeout_raises(self, mocker) -> None:
+        mocker.patch("confluent_sql.connectors.sleep_with_backoff", return_value=iter([]))
+        ctx = FakeControlPlane()
+        ctx.queue("delete", _ok_response())
+        ctx.queue("read", _ok_response(_read_body()))
+        ctx.queue("status", _ok_response(_status_body("RUNNING")))
+        api = ConnectorApi(ctx)
+
+        with pytest.raises(OperationalError, match="was not removed"):
+            api.delete("MyDatagen", timeout=5)

--- a/tests/unit/test_connectors_unit.py
+++ b/tests/unit/test_connectors_unit.py
@@ -1,0 +1,207 @@
+"""Unit tests for the network-free connector types, payload builder, and response parsers."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from confluent_sql.connectors import (
+    Connector,
+    ConnectorSpec,
+    ConnectorState,
+    ConnectorStatus,
+    TaskStatus,
+    build_create_payload,
+)
+from confluent_sql.exceptions import InterfaceError, OperationalError
+
+pytestmark = pytest.mark.unit
+
+
+def _read_body() -> dict:
+    """A `GET/POST .../connectors/{name}` body: config/tasks/type, never lifecycle state."""
+    return {
+        "name": "MyDatagen",
+        "config": {
+            "connector.class": "DatagenSource",
+            "name": "MyDatagen",
+            "kafka.api.key": "KEY",
+            "kafka.api.secret": "****",
+            "quickstart": "ORDERS",
+        },
+        "tasks": [{"connector": "MyDatagen", "task": 0}],
+        "type": "source",
+    }
+
+
+def _status_body() -> dict:
+    """A `GET .../connectors/{name}/status` body: the only place `connector.state` lives."""
+    return {
+        "name": "MyDatagen",
+        "type": "source",
+        "connector": {"state": "RUNNING", "worker_id": "w-1", "trace": ""},
+        "tasks": [{"id": 0, "state": "RUNNING", "worker_id": "w-1"}],
+        "plugin_lifecycle": "ACTIVE",
+    }
+
+
+class TestConnectorState:
+    """The lifecycle enum is extensible and knows which states end a create-wait."""
+
+    @pytest.mark.parametrize(
+        ("state", "terminal"),
+        [
+            (ConnectorState.RUNNING, True),
+            (ConnectorState.FAILED, True),
+            (ConnectorState.PROVISIONING, False),
+            (ConnectorState.NONE, False),
+            (ConnectorState.DEGRADED, False),
+            (ConnectorState.PAUSED, False),
+            (ConnectorState.DELETED, False),
+            (ConnectorState.UNKNOWN, False),
+        ],
+    )
+    def test_is_terminal(self, state: ConnectorState, terminal: bool) -> None:
+        assert state.is_terminal is terminal
+
+    def test_unknown_value_maps_to_unknown(self) -> None:
+        assert ConnectorState("SOMETHING_NEW") is ConnectorState.UNKNOWN
+
+    def test_missing_value_maps_to_unknown(self) -> None:
+        assert ConnectorState(None) is ConnectorState.UNKNOWN
+
+
+def _valid_config() -> dict:
+    """The minimal config the create payload requires: class plus the Kafka keypair."""
+    return {
+        "connector.class": "DatagenSource",
+        "kafka.api.key": "K",
+        "kafka.api.secret": "S",
+    }
+
+
+class TestBuildCreatePayload:
+    """`build_create_payload` requires the spec-required config keys and reconciles the name."""
+
+    def test_minimal_injects_name_into_config(self) -> None:
+        payload = build_create_payload(name="MyDatagen", config=_valid_config())
+        assert payload == {
+            "name": "MyDatagen",
+            "config": {
+                "connector.class": "DatagenSource",
+                "kafka.api.key": "K",
+                "kafka.api.secret": "S",
+                "name": "MyDatagen",
+            },
+        }
+
+    def test_does_not_mutate_caller_config(self) -> None:
+        config = _valid_config()
+        build_create_payload(name="MyDatagen", config=config)
+        assert "name" not in config
+
+    @pytest.mark.parametrize("missing", ["connector.class", "kafka.api.key", "kafka.api.secret"])
+    def test_missing_required_key_raises(self, missing: str) -> None:
+        config = _valid_config()
+        del config[missing]
+        with pytest.raises(InterfaceError, match=re.escape(missing)):
+            build_create_payload(name="MyDatagen", config=config)
+
+    def test_name_mismatch_raises(self) -> None:
+        with pytest.raises(InterfaceError, match="does not match connector name 'MyDatagen'"):
+            build_create_payload(name="MyDatagen", config={**_valid_config(), "name": "Other"})
+
+    def test_matching_name_kept(self) -> None:
+        payload = build_create_payload(
+            name="MyDatagen", config={**_valid_config(), "name": "MyDatagen"}
+        )
+        assert payload["config"]["name"] == "MyDatagen"
+
+
+class TestConnectorSpecFromResponse:
+    """`ConnectorSpec.from_response` parses the config/tasks/type read; no state present."""
+
+    def test_parses_fields(self) -> None:
+        spec = ConnectorSpec.from_response(_read_body())
+        assert spec.name == "MyDatagen"
+        assert spec.connector_class == "DatagenSource"
+        assert spec.type == "source"
+        assert spec.config["quickstart"] == "ORDERS"
+        assert spec.tasks == [{"connector": "MyDatagen", "task": 0}]
+
+    def test_connector_class_none_when_absent(self) -> None:
+        body = _read_body()
+        del body["config"]["connector.class"]
+        assert ConnectorSpec.from_response(body).connector_class is None
+
+    def test_missing_required_key_raises_operational(self) -> None:
+        body = _read_body()
+        del body["config"]
+        with pytest.raises(OperationalError, match="config"):
+            ConnectorSpec.from_response(body)
+
+
+class TestTaskStatusFromResponse:
+    """`TaskStatus.from_response` parses a single per-task status entry."""
+
+    def test_parses_fields(self) -> None:
+        task = TaskStatus.from_response(
+            {"id": 3, "state": "FAILED", "worker_id": "w-9", "msg": "boom"}
+        )
+        assert (task.id, task.state, task.worker_id, task.msg) == (3, "FAILED", "w-9", "boom")
+
+    def test_optional_msg_defaults_none(self) -> None:
+        task = TaskStatus.from_response({"id": 0, "state": "RUNNING", "worker_id": "w-1"})
+        assert task.msg is None
+
+
+class TestConnectorStatusFromResponse:
+    """`ConnectorStatus.from_response` parses the `/status` body, where state lives."""
+
+    def test_parses_fields(self) -> None:
+        status = ConnectorStatus.from_response(_status_body())
+        assert status.state is ConnectorState.RUNNING
+        assert status.worker_id == "w-1"
+        assert status.trace is None
+        assert status.plugin_lifecycle == "ACTIVE"
+        assert len(status.tasks) == 1
+        assert status.tasks[0].state == "RUNNING"
+
+    def test_extensible_state_is_lenient(self) -> None:
+        body = _status_body()
+        body["connector"]["state"] = "SOMETHING_NEW"
+        assert ConnectorStatus.from_response(body).state is ConnectorState.UNKNOWN
+
+    def test_trace_retained_when_present(self) -> None:
+        body = _status_body()
+        body["connector"]["state"] = "FAILED"
+        body["connector"]["trace"] = "java.lang.RuntimeException: nope"
+        status = ConnectorStatus.from_response(body)
+        assert status.state is ConnectorState.FAILED
+        assert status.trace == "java.lang.RuntimeException: nope"
+
+    def test_missing_connector_key_raises_operational(self) -> None:
+        body = _status_body()
+        del body["connector"]
+        with pytest.raises(OperationalError, match="connector"):
+            ConnectorStatus.from_response(body)
+
+
+class TestConnectorFromResponse:
+    """`Connector.from_response` merges the config read and the status read."""
+
+    def test_merges_read_and_status(self) -> None:
+        connector = Connector.from_response(_read_body(), _status_body())
+        assert connector.spec.connector_class == "DatagenSource"
+        assert connector.status.state is ConnectorState.RUNNING
+
+    def test_state_convenience_reads_status(self) -> None:
+        connector = Connector.from_response(_read_body(), _status_body())
+        assert connector.state is ConnectorState.RUNNING
+
+    def test_missing_key_raises_operational(self) -> None:
+        bad_read = _read_body()
+        del bad_read["name"]
+        with pytest.raises(OperationalError, match="name"):
+            Connector.from_response(bad_read, _status_body())


### PR DESCRIPTION
# Core connector lifecycle: create / get / delete

The foundation child of #121, mirroring what PR #117 did for Tableflow: the minimal
enable→check→teardown arc for Confluent **managed** connectors, plus the reusable plumbing and
the module/seam pattern the later children (#123–#127) build on.

## `connectors.py` — pure layer + orchestration + a context seam

- A network-free **pure layer**: typed `Connector` / `ConnectorSpec` / `ConnectorStatus`,
  the `ConnectorState` extensible enum (`NONE … DELETED`, unknowns → `UNKNOWN`), `TaskStatus`,
  `build_create_payload`, and `Connector.from_response`. Trivially unit-testable with zero
  mocks. Mirrors the `tableflow.py` precedent.
- An **orchestration layer**, `ConnectorApi`, holding the HTTP+poll choreography
  (`create` / `get` / `delete` + the waits). Polls via `sleep_with_backoff`, blocks by default
  per the repo's `wait_for_<settled-state>` convention.
- A narrow **`ControlPlaneContext` protocol** as the seam: `ConnectorApi` depends on it, not on
  `Connection`, so `connection` imports `connectors` and never the reverse. Makes `ConnectorApi`
  testable against a tiny fake context.

## Wire-shape facts the Connect v1 spec forced (vs. a naive Tableflow copy)

- **State lives only at `/status`.** Both `POST` and `GET .../connectors/{name}` return
  `config`/`tasks`/`type` but no state; `connector.state` comes from
  `GET .../connectors/{name}/status`. So `get_connector` issues two GETs and merges, and
  `create_connector` always does one status read to populate a real (not synthesized) state.
- `kafka.api.key` / `kafka.api.secret` are **required inside the open-ended `config` map** for a
  managed connector (per the create body's `config.required`) — kept in the map rather than
  promoted to kwargs. `build_create_payload` validates their presence (alongside `connector.class`)
  so an omission fails fast locally instead of as an opaque server 400. Reusing the connection's
  global API key as this keypair to spare re-provisioning is deferred to spike #130.
- The API field is `state`, so the convenience is `Connector.state` (not `.phase`).

## Methods on `Connection` (slim passthroughs)

- `create_connector(name, *, config, wait_for_running=True, timeout=...)`
- `get_connector(name)` — 404 → `ConnectorNotFoundError`
- `delete_connector(name, *, wait_for_removal=True, timeout=...)`

Each is a one-line delegation to a lazily-composed `ConnectorApi`.

## Auth

A global key covers Connect routes; otherwise a dedicated `connect_api_key` / `connect_api_secret`
connect-time pair (symmetric with `tableflow_api_key`), resolved by `_resolve_connect_credentials`
and routed through its own lazily-built control-plane client.

## Tests

- The pure layer and `ConnectorApi` are unit-tested with zero network: the pure parsers/builders
  directly, and `ConnectorApi` against a ~20-line fake `ControlPlaneContext` that scripts the
  HTTP responses (incl. the create→PROVISIONING→RUNNING transition, FAILED, 404/409, and the
  removal poll loop). Both modules hit 100% of their changed lines.
- A `tests/unit/test_connection_connector_unit.py` covers the Connection wiring: connect-credential
  resolution, the distinct connect-authed control-plane client, protocol satisfaction, and the
  three passthroughs.
- An env-gated Datagen-source integration arc exercises create → RUNNING → delete → gone end to end.

## Relationships

- Closes #122.
- Child of #121.
- Establishes the `ControlPlaneContext` + `*Api` pattern that #123–#127 extend; retrofitting Tableflow onto the same seam is deferred to #129.
- Spun out spike #130 (reuse the connection's global API key as the connector Kafka keypair) from the required-keypair decision here.


## References

- [Confluent Connectors](https://docs.confluent.io/cloud/current/connectors/overview.html) overview documentation
- [Confluent Connectors Core API Docs](https://docs.confluent.io/cloud/current/ccloud/connectors-connect-v-1/)