### PR TITLE
[v0.4.x] Harden idempotent GET requests vs transient networking errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this dbapi driver will be documented in this file.
 
+## 0.4.1
+
+### Fixed
+
+- Idempotent GET requests (`list_statements()`'s page-fetch loop, `get_statement()`, and result-page fetching) now retry transient transport errors -- connection resets (`httpx.NetworkError`) and servers that close pooled connections without responding (`httpx.RemoteProtocolError`) -- up to 3 times with a short exponential backoff, instead of failing on the first blip. POST/PATCH/DELETE requests (statement submission, `stop_statement()`, `delete_statement()`) are deliberately left unretried, since re-issuing them after a connection reset could double-submit or double-mutate state. (#137)
+
 ## 0.4.0, 2026-06-15
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,11 @@
 
 `Connection` exposes two ways to issue an HTTP request (`src/confluent_sql/connection.py`):
 
-- `_request_get(url, params=None)` — for idempotent GETs. Wraps `call_with_retries()`
-  (`src/confluent_sql/retry.py`), which retries transient transport errors (`httpx.NetworkError`,
-  `httpx.RemoteProtocolError`) with a short exponential backoff before giving up.
+- `_request_get(url, **kwargs)` — for idempotent GETs. Forwards `kwargs` (`params`, `headers`,
+  `timeout`, etc.) to `_request`, forcing `method="GET"`, and wraps the whole call in
+  `call_with_retries()` (`src/confluent_sql/retry.py`), which retries transient transport errors
+  (`httpx.NetworkError`, `httpx.RemoteProtocolError`) with a short exponential backoff before
+  giving up.
 - `_request(url, method="GET", ...)` — for everything else, including POST/PATCH/DELETE.
 
 **Every idempotent GET call site must go through `_request_get`, not `_request` directly.**
@@ -16,5 +18,8 @@ can double-submit or double-mutate state. When adding a new GET call site (e.g. 
 mutating call site, use `_request` directly and do not wrap it in retry logic.
 
 This distinction was introduced in #137 (see `CHANGELOG.md` 0.4.1) after a reported
-`ECONNRESET` on `list_statements()`; the reasoning and the case for a plain function over a
-decorator is captured in `retry.py`'s module docstring and `_request_get`'s docstring.
+`ECONNRESET` while polling a single statement via `get_statement()`/`_get_statement()`; the same
+PR additionally retries `list_statements()`'s page-fetch loop and result-page fetching, since
+those are equally idempotent GETs even though they weren't the reported failure. The reasoning,
+and the case for a plain function over a decorator, is captured in `retry.py`'s module docstring
+and `_request_get`'s docstring.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,20 @@
+# Project-specific instructions for confluent-sql
+
+## HTTP request routing: idempotent GETs vs mutating requests
+
+`Connection` exposes two ways to issue an HTTP request (`src/confluent_sql/connection.py`):
+
+- `_request_get(url, params=None)` — for idempotent GETs. Wraps `call_with_retries()`
+  (`src/confluent_sql/retry.py`), which retries transient transport errors (`httpx.NetworkError`,
+  `httpx.RemoteProtocolError`) with a short exponential backoff before giving up.
+- `_request(url, method="GET", ...)` — for everything else, including POST/PATCH/DELETE.
+
+**Every idempotent GET call site must go through `_request_get`, not `_request` directly.**
+Re-issuing a GET after a dropped connection is safe; re-issuing a POST/PATCH/DELETE is not — it
+can double-submit or double-mutate state. When adding a new GET call site (e.g. a future
+`list_connectors()` or similar read-only endpoint), route it through `_request_get`. When adding a
+mutating call site, use `_request` directly and do not wrap it in retry logic.
+
+This distinction was introduced in #137 (see `CHANGELOG.md` 0.4.1) after a reported
+`ECONNRESET` on `list_statements()`; the reasoning and the case for a plain function over a
+decorator is captured in `retry.py`'s module docstring and `_request_get`'s docstring.

--- a/src/confluent_sql/connection.py
+++ b/src/confluent_sql/connection.py
@@ -29,6 +29,7 @@ from .exceptions import (
 )
 from .execution_mode import ExecutionMode
 from .polling import sleep_with_backoff
+from .retry import call_with_retries
 from .statement import LABEL_PREFIX as STATEMENT_LABEL_PREFIX
 from .statement import ChangelogRow, Statement
 from .types import PropertiesDict, RowPythonTypes
@@ -811,7 +812,7 @@ class Connection:
         has_more_pages = True
         next_page_token: str | None = None
         while has_more_pages:
-            response = self._request("/statements", params=parameters)
+            response = self._request_get("/statements", params=parameters)
             resp_json = response.json()
             statements_json = resp_json.get("data", [])
             statements.extend(Statement.from_response(self, s) for s in statements_json)
@@ -1319,7 +1320,7 @@ class Connection:
             OperationalError: If other API errors occur
         """
         try:
-            return self._request(f"/statements/{statement_name}").json()
+            return self._request_get(f"/statements/{statement_name}").json()
         except OperationalError as e:
             # Check if this is a 404 error
             if e.http_status_code == 404:
@@ -1353,7 +1354,7 @@ class Connection:
             next_url = f"/statements/{statement_name}/results"
 
         try:
-            response = self._request(next_url).json()
+            response = self._request_get(next_url).json()
         except OperationalError as e:
             # Check if this is a 404 error indicating the statement was deleted
             if e.http_status_code == 404:
@@ -1401,6 +1402,14 @@ class Connection:
         next_url = response.get("metadata", {}).get("next") or None
 
         return (results, next_url)
+
+    def _request_get(self, url, params=None) -> httpx.Response:
+        """Issue a GET, retrying transient transport errors (#137).
+
+        Only for idempotent GETs -- retrying a call with side effects (POST/PATCH/DELETE) could
+        double-submit or double-mutate state, so those call sites use `_request` directly.
+        """
+        return call_with_retries(self._request, url, params=params)
 
     def _request(self, url, method="GET", raise_for_status=True, **kwargs) -> httpx.Response:
         if self._closed:

--- a/src/confluent_sql/connection.py
+++ b/src/confluent_sql/connection.py
@@ -1403,13 +1403,17 @@ class Connection:
 
         return (results, next_url)
 
-    def _request_get(self, url, params=None) -> httpx.Response:
+    def _request_get(self, url, **kwargs) -> httpx.Response:
         """Issue a GET, retrying transient transport errors (#137).
 
         Only for idempotent GETs -- retrying a call with side effects (POST/PATCH/DELETE) could
         double-submit or double-mutate state, so those call sites use `_request` directly.
+        Forwards arbitrary kwargs (params, headers, timeout, etc.) to `_request`, forcing
+        `method="GET"` regardless of what's passed, so a call site cannot accidentally opt out of
+        the retry policy just because it needs a kwarg beyond `params`.
         """
-        return call_with_retries(self._request, url, params=params)
+        kwargs["method"] = "GET"
+        return call_with_retries(self._request, url, **kwargs)
 
     def _request(self, url, method="GET", raise_for_status=True, **kwargs) -> httpx.Response:
         if self._closed:

--- a/src/confluent_sql/retry.py
+++ b/src/confluent_sql/retry.py
@@ -1,0 +1,75 @@
+"""Retry helper for idempotent, side-effect-free calls.
+
+Centralizes retrying of calls that intermittently fail with transient transport errors, so this
+policy lives in one place rather than being reimplemented at each call site. Only appropriate for
+calls where re-issuing after a partial failure is safe -- retrying a call with side effects (e.g. a
+POST that already reached the server before the response was lost) could double-submit or
+double-mutate state.
+"""
+
+import logging
+import random
+import time
+from collections.abc import Callable
+from typing import TypeVar
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+DEFAULT_RETRYABLE_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    httpx.NetworkError,
+    httpx.RemoteProtocolError,
+)
+"""Transient transport errors worth retrying: connection resets/drops (httpx.NetworkError covers
+ConnectError/ReadError/WriteError/CloseError) and servers that close pooled connections without
+responding (httpx.RemoteProtocolError). httpx.TimeoutException is deliberately excluded --
+retrying a timeout compounds latency (up to (max_retries + 1)x the configured timeout) rather than
+recovering from a blip; pass a custom `exceptions` tuple to opt in."""
+
+_RETRY_BASE_DELAY_SECS = 0.1
+"""Delay before the first retry sleep -- tuned for sub-second transient network blips rather than
+the multi-second server-state polling that polling.sleep_with_backoff paces."""
+
+_RETRY_DELAY_GROWTH = 2.0
+"""Multiplier applied to the delay after each retry."""
+
+_RETRY_JITTER_BAND = (0.75, 1.25)
+"""Multiplicative jitter band (+-25%) applied to each sleep to avoid thundering-herd alignment."""
+
+
+def call_with_retries(
+    func: Callable[..., T],
+    *args,
+    max_retries: int = 3,
+    exceptions: tuple[type[BaseException], ...] = DEFAULT_RETRYABLE_EXCEPTIONS,
+    **kwargs,
+) -> T:
+    """Call func(*args, **kwargs), retrying up to max_retries times on the given exceptions.
+
+    Sleeps a short exponential backoff with jitter between attempts and logs one INFO line per
+    retry naming the attempt number. After max_retries retries (max_retries + 1 total attempts),
+    the original exception from the final attempt is re-raised.
+    """
+    delay = _RETRY_BASE_DELAY_SECS
+    attempt = 0
+    while True:
+        try:
+            return func(*args, **kwargs)
+        except exceptions as e:
+            attempt += 1
+            if attempt > max_retries:
+                raise
+            sleep_secs = delay * random.uniform(*_RETRY_JITTER_BAND)
+            logger.info(
+                'Retrying %s after transient error (attempt %d/%d): "%s"; sleeping %.3fs',
+                getattr(func, "__name__", repr(func)),
+                attempt,
+                max_retries,
+                e,
+                sleep_secs,
+            )
+            time.sleep(sleep_secs)
+            delay *= _RETRY_DELAY_GROWTH

--- a/tests/integration/test_connection.py
+++ b/tests/integration/test_connection.py
@@ -8,6 +8,7 @@ Credentials must be provided via environment variables.
 import os
 import time
 
+import httpx
 import pytest
 
 import confluent_sql
@@ -271,6 +272,49 @@ class TestConnection:
 
         # Verify exception has statement name
         assert exc_info.value.statement_name == "non-existent-statement-name"
+
+
+@pytest.mark.integration
+class TestRetryOnTransientResultFetchErrors:
+    """Integration coverage for #137's retry-on-idempotent-GET behavior."""
+
+    def test_result_fetch_retries_past_simulated_econnresets_then_hits_confluent_cloud_for_real(
+        self, connection: Connection, mocker
+    ):
+        """Simulates two ECONNRESET-style drops on the results-fetch GET, then lets the third
+        attempt travel all the way through to Confluent Cloud for real.
+
+        NOTE: this is largely redundant with the fully-mocked coverage in
+        tests/unit/test_retry_unit.py and TestConnectionRetriesIdempotentGets
+        (tests/unit/test_connection_unit.py) -- those already prove call_with_retries' counting,
+        backoff, and exception-filtering, and that Connection wires it into
+        _get_statement_results correctly. It's written anyway, against a real environment, in
+        the spirit of treating #137 as a release-branch bugfix: showing the retry survives an
+        actual round trip is worth the extra network call, not just asserting it in the abstract.
+        """
+        with connection.closing_cursor() as cursor:
+            cursor.execute("SELECT 1 as answer FROM `INFORMATION_SCHEMA`.`TABLES`")
+
+            # Capture the real bound method before patching so the third call can still reach
+            # Confluent Cloud for real.
+            real_request = connection._client.request
+            call_count = 0
+
+            def flaky_then_real_request(*args, **kwargs):
+                nonlocal call_count
+                call_count += 1
+                if call_count <= 2:
+                    raise httpx.ReadError("[Errno 54] Connection reset by peer")
+                return real_request(*args, **kwargs)
+
+            request_mock = mocker.patch.object(
+                connection._client, "request", side_effect=flaky_then_real_request
+            )
+
+            row = cursor.fetchone()
+
+            assert row == (1,)
+            assert request_mock.call_count == 3
 
 
 @pytest.mark.integration

--- a/tests/unit/test_connection_unit.py
+++ b/tests/unit/test_connection_unit.py
@@ -1670,6 +1670,41 @@ class TestConnectionRetriesIdempotentGets:
 
         request_mock.assert_called_once()
 
+    def test_request_get_forwards_arbitrary_kwargs_to_request(
+        self,
+        invalid_credential_connection: Connection,
+        mocker,
+    ):
+        """A future GET call site needing e.g. headers/timeout must not have to bypass
+        _request_get (and thus the retry policy) just because _request_get only knew about
+        `params`."""
+        request_mock = mocker.patch.object(
+            invalid_credential_connection._client, "request", return_value=Mock()
+        )
+
+        invalid_credential_connection._request_get(
+            "/statements", headers={"X-Test": "1"}, timeout=5
+        )
+
+        request_mock.assert_called_once_with(
+            "GET", "/statements", headers={"X-Test": "1"}, timeout=5
+        )
+
+    def test_request_get_forces_get_method_even_if_caller_passes_method(
+        self,
+        invalid_credential_connection: Connection,
+        mocker,
+    ):
+        """_request_get must never issue anything but a GET, even if a caller mistakenly
+        passes a method= kwarg -- that guarantee is what makes it safe to retry."""
+        request_mock = mocker.patch.object(
+            invalid_credential_connection._client, "request", return_value=Mock()
+        )
+
+        invalid_credential_connection._request_get("/statements", method="POST")
+
+        request_mock.assert_called_once_with("GET", "/statements")
+
 
 @pytest.mark.unit
 class TestExecuteStatement:

--- a/tests/unit/test_connection_unit.py
+++ b/tests/unit/test_connection_unit.py
@@ -1562,6 +1562,116 @@ class TestGetStatement:
 
 
 @pytest.mark.unit
+class TestConnectionRetriesIdempotentGets:
+    """Tests that idempotent GET paths retry transient transport errors (#137), while
+    mutating (POST/PATCH/DELETE) paths deliberately do not."""
+
+    def test_list_statements_retries_and_succeeds(
+        self,
+        invalid_credential_connection: Connection,
+        statement_response_factory: StatementResponseFactory,
+        mocker,
+    ):
+        mocker.patch("confluent_sql.retry.time.sleep")
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "data": [statement_response_factory(name="stmt-1")],
+            "metadata": {},
+        }
+        request_mock = mocker.patch.object(
+            invalid_credential_connection._client,
+            "request",
+            side_effect=[httpx.ReadError("reset"), mock_response],
+        )
+
+        statements = invalid_credential_connection.list_statements()
+
+        assert [s.name for s in statements] == ["stmt-1"]
+        assert request_mock.call_count == 2
+
+    def test_get_statement_retries_and_succeeds(
+        self,
+        invalid_credential_connection: Connection,
+        statement_response_factory: StatementResponseFactory,
+        mocker,
+    ):
+        mocker.patch("confluent_sql.retry.time.sleep")
+        mock_response = Mock()
+        mock_response.json.return_value = statement_response_factory(name="stmt-1")
+        request_mock = mocker.patch.object(
+            invalid_credential_connection._client,
+            "request",
+            side_effect=[httpx.ReadError("reset"), mock_response],
+        )
+
+        result = invalid_credential_connection._get_statement("stmt-1")
+
+        assert result["name"] == "stmt-1"
+        assert request_mock.call_count == 2
+
+    def test_get_statement_results_retries_and_succeeds(
+        self,
+        invalid_credential_connection: Connection,
+        mocker,
+    ):
+        mocker.patch("confluent_sql.retry.time.sleep")
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "results": {"data": [{"row": ["v1"]}]},
+            "metadata": {},
+        }
+        request_mock = mocker.patch.object(
+            invalid_credential_connection._client,
+            "request",
+            side_effect=[httpx.ReadError("reset"), mock_response],
+        )
+
+        results, next_url = invalid_credential_connection._get_statement_results("stmt-1", None)
+
+        assert [r.row for r in results] == [["v1"]]
+        assert next_url is None
+        assert request_mock.call_count == 2
+
+    def test_idempotent_get_reraises_original_exception_after_exhausting_retries(
+        self,
+        invalid_credential_connection: Connection,
+        mocker,
+    ):
+        """Documents today's unwrapped-transport-error behavior (tracked as #138): after retries
+        are exhausted, the raw httpx exception propagates rather than an OperationalError."""
+        mocker.patch("confluent_sql.retry.time.sleep")
+        request_mock = mocker.patch.object(
+            invalid_credential_connection._client,
+            "request",
+            side_effect=[httpx.ReadError("reset")] * 4,
+        )
+
+        with pytest.raises(httpx.ReadError):
+            invalid_credential_connection._get_statement("stmt-1")
+
+        assert request_mock.call_count == 4
+
+    def test_non_idempotent_path_does_not_retry_on_transient_error(
+        self,
+        invalid_credential_connection: Connection,
+        mocker,
+    ):
+        """delete_statement's DELETE must not be retried: retrying a mutating call after a
+        connection reset could double-mutate state, which is exactly what #137 scopes retries
+        away from."""
+        request_mock = mocker.patch.object(
+            invalid_credential_connection._client,
+            "request",
+            side_effect=httpx.ReadError("reset"),
+        )
+
+        with pytest.raises(httpx.ReadError):
+            invalid_credential_connection.delete_statement("stmt-1")
+
+        request_mock.assert_called_once()
+
+
+@pytest.mark.unit
 class TestExecuteStatement:
     """Tests for _execute_statement method."""
 

--- a/tests/unit/test_retry_unit.py
+++ b/tests/unit/test_retry_unit.py
@@ -1,0 +1,131 @@
+import logging
+from unittest.mock import Mock
+
+import httpx
+import pytest
+
+from confluent_sql import retry
+from confluent_sql.retry import DEFAULT_RETRYABLE_EXCEPTIONS, call_with_retries
+
+
+@pytest.fixture()
+def no_sleep(mocker):
+    """Patch away real sleeping so retry tests run instantly, while still letting call counts and
+    sleep durations be asserted."""
+    return mocker.patch.object(retry.time, "sleep")
+
+
+@pytest.fixture()
+def no_jitter(mocker):
+    """Pin jitter to 1.0 so sleep durations are deterministic."""
+    return mocker.patch.object(retry.random, "uniform", return_value=1.0)
+
+
+@pytest.mark.unit
+class TestCallWithRetries:
+    def test_succeeds_without_retrying(self, no_sleep):
+        func = Mock(return_value="ok")
+
+        result = call_with_retries(func, "a", b="c")
+
+        assert result == "ok"
+        func.assert_called_once_with("a", b="c")
+        no_sleep.assert_not_called()
+
+    def test_retries_and_eventually_succeeds(self, no_sleep, no_jitter):
+        func = Mock(
+            side_effect=[
+                httpx.ReadError("boom"),
+                httpx.ReadError("boom again"),
+                "ok",
+            ]
+        )
+
+        result = call_with_retries(func, "a", b="c")
+
+        assert result == "ok"
+        assert func.call_count == 3
+        for call in func.call_args_list:
+            assert call.args == ("a",)
+            assert call.kwargs == {"b": "c"}
+
+    def test_exhausts_retries_and_reraises_original_exception(self, no_sleep, no_jitter):
+        original = httpx.ReadError("boom")
+        func = Mock(side_effect=[original, httpx.ReadError("2"), httpx.ReadError("3"), original])
+
+        with pytest.raises(httpx.ReadError) as exc_info:
+            call_with_retries(func, max_retries=3)
+
+        assert exc_info.value is original
+        assert func.call_count == 4
+
+    def test_logs_one_info_record_per_retry_naming_attempt_number_and_exception_message(
+        self, no_sleep, no_jitter, caplog
+    ):
+        func = Mock(
+            side_effect=[
+                httpx.ReadError("Connection reset by peer"),
+                httpx.RemoteProtocolError("Server disconnected without sending a response"),
+                "ok",
+            ]
+        )
+
+        with caplog.at_level(logging.INFO, logger=retry.logger.name):
+            call_with_retries(func, max_retries=3)
+
+        info_records = [r for r in caplog.records if r.levelno == logging.INFO]
+        assert len(info_records) == 2
+        assert "attempt 1/3" in info_records[0].message
+        assert '"Connection reset by peer"' in info_records[0].message
+        assert "attempt 2/3" in info_records[1].message
+        assert '"Server disconnected without sending a response"' in info_records[1].message
+
+    def test_non_retryable_exception_propagates_without_retry(self, no_sleep):
+        func = Mock(side_effect=ValueError("not retryable"))
+
+        with pytest.raises(ValueError, match="not retryable"):
+            call_with_retries(func)
+
+        func.assert_called_once()
+        no_sleep.assert_not_called()
+
+    def test_max_retries_zero_means_single_call_and_immediate_reraise(self, no_sleep):
+        func = Mock(side_effect=httpx.ReadError("boom"))
+
+        with pytest.raises(httpx.ReadError):
+            call_with_retries(func, max_retries=0)
+
+        func.assert_called_once()
+        no_sleep.assert_not_called()
+
+    def test_custom_exceptions_tuple_overrides_default_set(self, no_sleep, no_jitter):
+        func = Mock(side_effect=[ValueError("custom"), "ok"])
+
+        result = call_with_retries(func, exceptions=(ValueError,))
+
+        assert result == "ok"
+        assert func.call_count == 2
+
+    def test_backoff_grows_and_is_jittered(self, mocker, no_sleep):
+        uniform = mocker.patch.object(retry.random, "uniform", side_effect=[1.0, 0.75, 1.25])
+        func = Mock(
+            side_effect=[
+                httpx.ReadError("1"),
+                httpx.ReadError("2"),
+                httpx.ReadError("3"),
+                "ok",
+            ]
+        )
+
+        call_with_retries(func, max_retries=3)
+
+        slept = [call.args[0] for call in no_sleep.call_args_list]
+        assert len(slept) == 3
+        # Each successive base delay grows; jitter draws (1.0, 0.75, 1.25) scale it further.
+        assert slept[0] < slept[1] < slept[2]
+        assert uniform.call_count == 3
+
+    def test_default_retryable_exceptions(self):
+        assert httpx.NetworkError in DEFAULT_RETRYABLE_EXCEPTIONS
+        assert httpx.RemoteProtocolError in DEFAULT_RETRYABLE_EXCEPTIONS
+        assert httpx.TimeoutException not in DEFAULT_RETRYABLE_EXCEPTIONS

--- a/tests/unit/test_retry_unit.py
+++ b/tests/unit/test_retry_unit.py
@@ -129,3 +129,16 @@ class TestCallWithRetries:
         assert httpx.NetworkError in DEFAULT_RETRYABLE_EXCEPTIONS
         assert httpx.RemoteProtocolError in DEFAULT_RETRYABLE_EXCEPTIONS
         assert httpx.TimeoutException not in DEFAULT_RETRYABLE_EXCEPTIONS
+
+    def test_default_exceptions_do_not_retry_timeout(self, no_sleep):
+        """Tuple membership alone (test_default_retryable_exceptions above) doesn't prove
+        httpx.TimeoutException is never retried -- it would still be caught if it were a
+        subclass of one of the default exceptions. Assert the actual behavior instead: a timeout
+        propagates on the first call, with no retry and no sleep."""
+        func = Mock(side_effect=httpx.TimeoutException("timed out"))
+
+        with pytest.raises(httpx.TimeoutException):
+            call_with_retries(func)
+
+        func.assert_called_once()
+        no_sleep.assert_not_called()


### PR DESCRIPTION
Harden idempotent GET requests vs transient networking errors by catching and retrying a reasonable number of times. Done as a higher-order-function instead of a decorator at this time because only one single (new) method would be decorated -- a new function funneling through all GET requests done by class Connection. Done as a split between the new method in Connection vs the HOF due to separation of concerns (retrying vs making a http GET) and clean testability.

If / when additional retry fodder becomes identified, then would write a decorator variant.

This is a patch against v0.4.x due to field reports of fails in GETing a single Statement due to "httpx.ReadError: [Errno 54] Connection reset by peer".

Closes #137 in v0.4.x timestream.

After this merges, would make a followup in v0.4.x stream to touchup the changelog (stamp release date) and then would publish a patch release. Then would cherry-pick both commits up into main.