### PR TITLE
Additional GET request hardening (#140)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this dbapi driver will be documented in this file.
 ### Fixed
 
 - Idempotent GET requests (`list_statements()`'s page-fetch loop, `get_statement()`, and result-page fetching) now retry transient transport errors -- connection resets (`httpx.NetworkError`) and servers that close pooled connections without responding (`httpx.RemoteProtocolError`) -- up to 3 times with a short exponential backoff, instead of failing on the first blip. POST/PATCH/DELETE requests (statement submission, `stop_statement()`, `delete_statement()`) are deliberately left unretried, since re-issuing them after a connection reset could double-submit or double-mutate state. (#137)
+- The same idempotent GET requests now also retry transient HTTP response statuses (429, 500, 502, 503, 504), not just transport-level exceptions -- a request that reaches Confluent Cloud but gets a momentarily-overloaded gateway response was previously failing on the first such response instead of being retried like a dropped connection. (#140)
 
 ## 0.4.0, 2026-06-15
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,12 @@
 
 - `_request_get(url, **kwargs)` — for idempotent GETs. Forwards `kwargs` (`params`, `headers`,
   `timeout`, etc.) to `_request`, forcing `method="GET"`, and wraps the whole call in
-  `call_with_retries()` (`src/confluent_sql/retry.py`), which retries transient transport errors
-  (`httpx.NetworkError`, `httpx.RemoteProtocolError`) with a short exponential backoff before
-  giving up.
+  `call_with_retries()` (`src/confluent_sql/retry.py`), which retries both transient transport
+  errors (`httpx.NetworkError`, `httpx.RemoteProtocolError`; #137) and transient HTTP response
+  statuses (429/500/502/503/504, via `DEFAULT_RETRYABLE_STATUS_CODES`; #140) with a short
+  exponential backoff before giving up. Status-code retries are wired in via a private
+  `_RetryableStatusError` sentinel raised inside `_request_get` -- `call_with_retries` itself
+  stays HTTP-agnostic, unchanged from #137.
 - `_request(url, method="GET", ...)` — for everything else, including POST/PATCH/DELETE.
 
 **Every idempotent GET call site must go through `_request_get`, not `_request` directly.**
@@ -20,6 +23,7 @@ mutating call site, use `_request` directly and do not wrap it in retry logic.
 This distinction was introduced in #137 (see `CHANGELOG.md` 0.4.1) after a reported
 `ECONNRESET` while polling a single statement via `get_statement()`/`_get_statement()`; the same
 PR additionally retries `list_statements()`'s page-fetch loop and result-page fetching, since
-those are equally idempotent GETs even though they weren't the reported failure. The reasoning,
-and the case for a plain function over a decorator, is captured in `retry.py`'s module docstring
-and `_request_get`'s docstring.
+those are equally idempotent GETs even though they weren't the reported failure. #140 extended
+the same call sites to also retry on retryable HTTP status codes, not just transport exceptions.
+The reasoning, and the case for a plain function over a decorator, is captured in `retry.py`'s
+module docstring and `_request_get`'s docstring.

--- a/src/confluent_sql/connection.py
+++ b/src/confluent_sql/connection.py
@@ -29,7 +29,11 @@ from .exceptions import (
 )
 from .execution_mode import ExecutionMode
 from .polling import sleep_with_backoff
-from .retry import DEFAULT_RETRYABLE_EXCEPTIONS, DEFAULT_RETRYABLE_STATUS_CODES, call_with_retries
+from .retry import (
+    DEFAULT_RETRYABLE_EXCEPTIONS,
+    DEFAULT_RETRYABLE_STATUS_CODES,
+    call_with_retries,
+)
 from .statement import LABEL_PREFIX as STATEMENT_LABEL_PREFIX
 from .statement import ChangelogRow, Statement
 from .types import PropertiesDict, RowPythonTypes

--- a/src/confluent_sql/connection.py
+++ b/src/confluent_sql/connection.py
@@ -29,7 +29,7 @@ from .exceptions import (
 )
 from .execution_mode import ExecutionMode
 from .polling import sleep_with_backoff
-from .retry import call_with_retries
+from .retry import DEFAULT_RETRYABLE_EXCEPTIONS, DEFAULT_RETRYABLE_STATUS_CODES, call_with_retries
 from .statement import LABEL_PREFIX as STATEMENT_LABEL_PREFIX
 from .statement import ChangelogRow, Statement
 from .types import PropertiesDict, RowPythonTypes
@@ -204,6 +204,15 @@ def connect(  # noqa: PLR0913
         http_user_agent=http_user_agent,
         http_timeout_secs=http_timeout_secs,
     )
+
+
+class _RetryableStatusError(Exception):
+    """Wraps a response carrying a retryable HTTP status (#140) so call_with_retries' existing
+    exception-based retry loop drives status-code retries too. Never escapes _request_get."""
+
+    def __init__(self, response: httpx.Response):
+        self.response = response
+        super().__init__(f"transient HTTP status {response.status_code}")
 
 
 class Connection:
@@ -1404,7 +1413,8 @@ class Connection:
         return (results, next_url)
 
     def _request_get(self, url, **kwargs) -> httpx.Response:
-        """Issue a GET, retrying transient transport errors (#137).
+        """Issue a GET, retrying transient transport errors (#137) and transient HTTP status
+        codes (#140) alike -- both feed the same call_with_retries backoff/attempt budget.
 
         Only for idempotent GETs -- retrying a call with side effects (POST/PATCH/DELETE) could
         double-submit or double-mutate state, so those call sites use `_request` directly.
@@ -1413,18 +1423,29 @@ class Connection:
         the retry policy just because it needs a kwarg beyond `params`.
         """
         kwargs["method"] = "GET"
-        return call_with_retries(self._request, url, **kwargs)
 
-    def _request(self, url, method="GET", raise_for_status=True, **kwargs) -> httpx.Response:
-        if self._closed:
-            raise InterfaceError("Connection is closed")
+        def _get_or_flag_retryable_status() -> httpx.Response:
+            response = self._request(url, raise_for_status=False, **kwargs)
+            if response.status_code in DEFAULT_RETRYABLE_STATUS_CODES:
+                raise _RetryableStatusError(response)
+            return response
 
         try:
-            response = self._client.request(method, url, **kwargs)
-            logger.debug("Response: %s", response.content)
-            if raise_for_status:
-                response.raise_for_status()
-            return response
+            response = call_with_retries(
+                _get_or_flag_retryable_status,
+                exceptions=(*DEFAULT_RETRYABLE_EXCEPTIONS, _RetryableStatusError),
+            )
+        except _RetryableStatusError as e:
+            response = e.response
+
+        self._raise_for_status_as_operational_error(response)
+        return response
+
+    def _raise_for_status_as_operational_error(self, response: httpx.Response) -> None:
+        """Translate a non-2xx response into OperationalError, chaining the original
+        httpx.HTTPStatusError and including any server-provided error detail."""
+        try:
+            response.raise_for_status()
         except httpx.HTTPStatusError as e:
             try:
                 res = e.response.json()
@@ -1437,6 +1458,16 @@ class Connection:
                 f"error sending request '{e.response.status_code}' - {details}",
                 http_status_code=e.response.status_code,
             ) from e
+
+    def _request(self, url, method="GET", raise_for_status=True, **kwargs) -> httpx.Response:
+        if self._closed:
+            raise InterfaceError("Connection is closed")
+
+        response = self._client.request(method, url, **kwargs)
+        logger.debug("Response: %s", response.content)
+        if raise_for_status:
+            self._raise_for_status_as_operational_error(response)
+        return response
 
     def _get_next_page_token(self, next_url: str | None) -> str | None:
         """Extract the next page token from the next_url, if present."""

--- a/src/confluent_sql/connection.py
+++ b/src/confluent_sql/connection.py
@@ -1446,7 +1446,7 @@ class Connection:
         return response
 
     def _raise_for_status_as_operational_error(self, response: httpx.Response) -> None:
-        """Translate a non-2xx response into OperationalError, chaining the original
+        """Translate a 4xx/5xx response into OperationalError, chaining the original
         httpx.HTTPStatusError and including any server-provided error detail."""
         try:
             response.raise_for_status()

--- a/src/confluent_sql/connection.py
+++ b/src/confluent_sql/connection.py
@@ -1424,9 +1424,12 @@ class Connection:
         double-submit or double-mutate state, so those call sites use `_request` directly.
         Forwards arbitrary kwargs (params, headers, timeout, etc.) to `_request`, forcing
         `method="GET"` regardless of what's passed, so a call site cannot accidentally opt out of
-        the retry policy just because it needs a kwarg beyond `params`.
+        the retry policy just because it needs a kwarg beyond `params`. `raise_for_status` is
+        dropped if present -- this method always manages it internally, since it must inspect
+        the raw response to decide whether to retry before translating a final error.
         """
         kwargs["method"] = "GET"
+        kwargs.pop("raise_for_status", None)
 
         def _get_or_flag_retryable_status() -> httpx.Response:
             response = self._request(url, raise_for_status=False, **kwargs)

--- a/src/confluent_sql/retry.py
+++ b/src/confluent_sql/retry.py
@@ -29,6 +29,13 @@ responding (httpx.RemoteProtocolError). httpx.TimeoutException is deliberately e
 retrying a timeout compounds latency (up to (max_retries + 1)x the configured timeout) rather than
 recovering from a blip; pass a custom `exceptions` tuple to opt in."""
 
+DEFAULT_RETRYABLE_STATUS_CODES: frozenset[int] = frozenset({429, 500, 502, 503, 504})
+"""HTTP statuses worth retrying on an idempotent GET: 429 (rate limited) and 500/502/503/504
+(gateway/server transients). Consumed by `Connection._request_get`, not by `call_with_retries`
+itself, which has no HTTP-specific knowledge. 408 (Request Timeout) is deliberately excluded --
+same "don't compound latency on a timeout" reasoning as excluding httpx.TimeoutException from
+DEFAULT_RETRYABLE_EXCEPTIONS above. Honoring a Retry-After header on 429/503 is out of scope."""
+
 _RETRY_BASE_DELAY_SECS = 0.1
 """Delay before the first retry sleep -- tuned for sub-second transient network blips rather than
 the multi-second server-state polling that polling.sleep_with_backoff paces."""

--- a/tests/unit/test_connection_unit.py
+++ b/tests/unit/test_connection_unit.py
@@ -1855,6 +1855,22 @@ class TestConnectionRetriesIdempotentGets:
 
         request_mock.assert_called_once_with("GET", "/statements")
 
+    def test_request_get_drops_caller_supplied_raise_for_status_kwarg(
+        self,
+        invalid_credential_connection: Connection,
+        mocker,
+    ):
+        """_request_get always manages raise_for_status itself (it must see the raw response
+        to decide whether to retry before translating it) -- a caller passing raise_for_status
+        in kwargs must not collide with that and blow up with a duplicate-keyword TypeError."""
+        request_mock = mocker.patch.object(
+            invalid_credential_connection._client, "request", return_value=Mock()
+        )
+
+        invalid_credential_connection._request_get("/statements", raise_for_status=True)
+
+        request_mock.assert_called_once_with("GET", "/statements")
+
 
 @pytest.mark.unit
 class TestExecuteStatement:

--- a/tests/unit/test_connection_unit.py
+++ b/tests/unit/test_connection_unit.py
@@ -1670,6 +1670,156 @@ class TestConnectionRetriesIdempotentGets:
 
         request_mock.assert_called_once()
 
+    def test_list_statements_retries_on_retryable_status_and_succeeds(
+        self,
+        invalid_credential_connection: Connection,
+        statement_response_factory: StatementResponseFactory,
+        mocker,
+    ):
+        mocker.patch("confluent_sql.retry.time.sleep")
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "data": [statement_response_factory(name="stmt-1")],
+            "metadata": {},
+        }
+        request_mock = mocker.patch.object(
+            invalid_credential_connection._client,
+            "request",
+            side_effect=[_http_error_response(503), mock_response],
+        )
+
+        statements = invalid_credential_connection.list_statements()
+
+        assert [s.name for s in statements] == ["stmt-1"]
+        assert request_mock.call_count == 2
+
+    def test_get_statement_retries_on_retryable_status_and_succeeds(
+        self,
+        invalid_credential_connection: Connection,
+        statement_response_factory: StatementResponseFactory,
+        mocker,
+    ):
+        mocker.patch("confluent_sql.retry.time.sleep")
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = statement_response_factory(name="stmt-1")
+        request_mock = mocker.patch.object(
+            invalid_credential_connection._client,
+            "request",
+            side_effect=[_http_error_response(503), mock_response],
+        )
+
+        result = invalid_credential_connection._get_statement("stmt-1")
+
+        assert result["name"] == "stmt-1"
+        assert request_mock.call_count == 2
+
+    def test_get_statement_results_retries_on_retryable_status_and_succeeds(
+        self,
+        invalid_credential_connection: Connection,
+        mocker,
+    ):
+        mocker.patch("confluent_sql.retry.time.sleep")
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "results": {"data": [{"row": ["v1"]}]},
+            "metadata": {},
+        }
+        request_mock = mocker.patch.object(
+            invalid_credential_connection._client,
+            "request",
+            side_effect=[_http_error_response(503), mock_response],
+        )
+
+        results, next_url = invalid_credential_connection._get_statement_results("stmt-1", None)
+
+        assert [r.row for r in results] == [["v1"]]
+        assert next_url is None
+        assert request_mock.call_count == 2
+
+    def test_idempotent_get_raises_operational_error_after_exhausting_status_retries(
+        self,
+        invalid_credential_connection: Connection,
+        mocker,
+    ):
+        """Unlike #137's transport-exception exhaustion (which leaks the raw httpx exception,
+        tracked as #138), a persistently-retryable status IS translated to OperationalError --
+        _raise_for_status_as_operational_error runs on the final response either way."""
+        mocker.patch("confluent_sql.retry.time.sleep")
+        request_mock = mocker.patch.object(
+            invalid_credential_connection._client,
+            "request",
+            side_effect=[_http_error_response(503)] * 4,
+        )
+
+        with pytest.raises(OperationalError) as exc_info:
+            invalid_credential_connection._get_statement("stmt-1")
+
+        assert exc_info.value.http_status_code == 503
+        assert request_mock.call_count == 4
+
+    def test_get_statement_does_not_retry_non_retryable_status(
+        self,
+        invalid_credential_connection: Connection,
+        mocker,
+    ):
+        """A 404 must not be treated as retryable -- it's the caller's job to see
+        StatementNotFoundError on the very first response, not after a wasted retry budget."""
+        request_mock = mocker.patch.object(
+            invalid_credential_connection._client,
+            "request",
+            return_value=_http_error_response(404),
+        )
+
+        with pytest.raises(StatementNotFoundError):
+            invalid_credential_connection._get_statement("stmt-1")
+
+        request_mock.assert_called_once()
+
+    def test_get_statement_retries_share_budget_across_transient_error_and_status(
+        self,
+        invalid_credential_connection: Connection,
+        statement_response_factory: StatementResponseFactory,
+        mocker,
+    ):
+        """A transport exception and a retryable status draw from the same attempt/backoff
+        budget -- proof that #140's status-code retries reuse #137's call_with_retries loop
+        rather than adding a second, independent retry mechanism."""
+        mocker.patch("confluent_sql.retry.time.sleep")
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = statement_response_factory(name="stmt-1")
+        request_mock = mocker.patch.object(
+            invalid_credential_connection._client,
+            "request",
+            side_effect=[httpx.ReadError("reset"), _http_error_response(503), mock_response],
+        )
+
+        result = invalid_credential_connection._get_statement("stmt-1")
+
+        assert result["name"] == "stmt-1"
+        assert request_mock.call_count == 3
+
+    def test_delete_statement_does_not_retry_on_retryable_status(
+        self,
+        invalid_credential_connection: Connection,
+        mocker,
+    ):
+        """delete_statement's DELETE must not be retried on a retryable status either -- #140's
+        status-code check must live in _request_get, not leak into _request itself."""
+        request_mock = mocker.patch.object(
+            invalid_credential_connection._client,
+            "request",
+            return_value=_http_error_response(503),
+        )
+
+        with pytest.raises(OperationalError, match="Error deleting statement"):
+            invalid_credential_connection.delete_statement("stmt-1")
+
+        request_mock.assert_called_once()
+
     def test_request_get_forwards_arbitrary_kwargs_to_request(
         self,
         invalid_credential_connection: Connection,

--- a/tests/unit/test_retry_unit.py
+++ b/tests/unit/test_retry_unit.py
@@ -5,7 +5,11 @@ import httpx
 import pytest
 
 from confluent_sql import retry
-from confluent_sql.retry import DEFAULT_RETRYABLE_EXCEPTIONS, call_with_retries
+from confluent_sql.retry import (
+    DEFAULT_RETRYABLE_EXCEPTIONS,
+    DEFAULT_RETRYABLE_STATUS_CODES,
+    call_with_retries,
+)
 
 
 @pytest.fixture()
@@ -142,3 +146,10 @@ class TestCallWithRetries:
 
         func.assert_called_once()
         no_sleep.assert_not_called()
+
+    def test_default_retryable_status_codes(self):
+        assert frozenset({429, 500, 502, 503, 504}) == DEFAULT_RETRYABLE_STATUS_CODES
+        assert 408 not in DEFAULT_RETRYABLE_STATUS_CODES
+        assert 200 not in DEFAULT_RETRYABLE_STATUS_CODES
+        assert 404 not in DEFAULT_RETRYABLE_STATUS_CODES
+        assert 400 not in DEFAULT_RETRYABLE_STATUS_CODES


### PR DESCRIPTION
## Retry idempotent GETs on retryable HTTP status codes too

- #137 only retries idempotent GETs on transport-level exceptions (`httpx.NetworkError`,
  `httpx.RemoteProtocolError`) — failures where no HTTP response was ever received. A GET that
  *does* get a response, but with a transient server-side status (429/500/502/503/504), wasn't
  retried at all: `_request()` converts that into an `OperationalError` on the very first such
  response, before `call_with_retries` ever sees an exception it's watching for. Found while
  researching how Confluent's own Java Table API client hardens itself against the same class of
  failure against the same REST API (`DefaultPluginContext.isRetryable`, which treats HTTP
  408/429/500/502/503/504 as retryable alongside raw connection errors).
- Closes the gap with a small private sentinel exception (`Connection._RetryableStatusError`)
  raised inside `_request_get` when a response's status lands in a new
  `DEFAULT_RETRYABLE_STATUS_CODES` set (`src/confluent_sql/retry.py`), rather than generalizing
  `call_with_retries` itself with a result-checking predicate. Considered the generalization first
  and rejected it: it would need the primitive to return a still-bad result on exhaustion instead
  of raising (asymmetric with its current always-raises contract), and would leak an
  httpx-shaped "how do I log this result" concern into an otherwise fully generic function. The
  sentinel approach means `call_with_retries` doesn't change at all — status-code retries just
  become one more entry in its existing `exceptions` tuple, and its whole test suite becomes free
  regression coverage for "status retries share the same backoff/attempt-counter/logging as
  transport-exception retries."
- Extracted `Connection._raise_for_status_as_operational_error(response)` out of `_request`'s
  existing `except httpx.HTTPStatusError` block so `_request_get` can translate the final
  (post-retry) response without re-issuing the request just to get the translated exception.
  Pure extraction — `delete_statement`/`stop_statement` already have their own separate,
  divergent 404 handling and never touched this block; left untouched, with a regression test
  guarding that a 503 on those paths still doesn't retry.
- 408 is deliberately excluded from `DEFAULT_RETRYABLE_STATUS_CODES`, same "don't compound
  latency on a timeout" reasoning #137 used to exclude `httpx.TimeoutException`. Honoring a
  `Retry-After` header on 429/503 is explicitly out of scope for this issue — noted as a possible
  future refinement, not resolved here.

- New tests added in `tests/unit/test_retry_unit.py` (`DEFAULT_RETRYABLE_STATUS_CODES` contents)
  and `tests/unit/test_connection_unit.py::TestConnectionRetriesIdempotentGets` (retry-then-succeed
  on each of the 3 GET call sites, exhaustion raising `OperationalError` with `http_status_code`
  set, a 404 regression guard proving non-retryable statuses aren't retried, a mixed
  transport-exception-then-status-retry test proving the shared backoff budget, and a
  `delete_statement` regression guard proving the status-code check doesn't leak into `_request`
  itself) — all written and confirmed red before the implementation landed.


## Relationships

Closes #140 (in `v1.4.x` timeline)
Related: #137 (introduced `call_with_retries`/`_request_get`), #138 (unwrapped exception
translation — adjacent to but not resolved by this issue)
