### PR TITLE
[0.4.x] More generous HTTP timeouts; stamp 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this dbapi driver will be documented in this file.
 
 - Idempotent GET requests (`list_statements()`'s page-fetch loop, `get_statement()`, and result-page fetching) now retry transient transport errors -- connection resets (`httpx.NetworkError`) and servers that close pooled connections without responding (`httpx.RemoteProtocolError`) -- up to 3 times with a short exponential backoff, instead of failing on the first blip. POST/PATCH/DELETE requests (statement submission, `stop_statement()`, `delete_statement()`) are deliberately left unretried, since re-issuing them after a connection reset could double-submit or double-mutate state. (#137)
 - The same idempotent GET requests now also retry transient HTTP response statuses (429, 500, 502, 503, 504), not just transport-level exceptions -- a request that reaches Confluent Cloud but gets a momentarily-overloaded gateway response was previously failing on the first such response instead of being retried like a dropped connection. (#140)
-- Increased the default HTTP timeout from 5 to 10s for saftey.
+- Increased the default HTTP timeout from 5 to 10s for safety. `connect()` and `Connection.__init__()` no longer accepts explicit `None` for `http_timeout_secs`.
 
 ## 0.4.0, 2026-06-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this dbapi driver will be documented in this file.
 
 - Idempotent GET requests (`list_statements()`'s page-fetch loop, `get_statement()`, and result-page fetching) now retry transient transport errors -- connection resets (`httpx.NetworkError`) and servers that close pooled connections without responding (`httpx.RemoteProtocolError`) -- up to 3 times with a short exponential backoff, instead of failing on the first blip. POST/PATCH/DELETE requests (statement submission, `stop_statement()`, `delete_statement()`) are deliberately left unretried, since re-issuing them after a connection reset could double-submit or double-mutate state. (#137)
 - The same idempotent GET requests now also retry transient HTTP response statuses (429, 500, 502, 503, 504), not just transport-level exceptions -- a request that reaches Confluent Cloud but gets a momentarily-overloaded gateway response was previously failing on the first such response instead of being retried like a dropped connection. (#140)
+- Increased the default HTTP timeout from 5 to 10s for saftey.
 
 ## 0.4.0, 2026-06-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this dbapi driver will be documented in this file.
 
-## 0.4.1
+## 0.4.1, 2026-07-07
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this dbapi driver will be documented in this file.
 
 - Idempotent GET requests (`list_statements()`'s page-fetch loop, `get_statement()`, and result-page fetching) now retry transient transport errors -- connection resets (`httpx.NetworkError`) and servers that close pooled connections without responding (`httpx.RemoteProtocolError`) -- up to 3 times with a short exponential backoff, instead of failing on the first blip. POST/PATCH/DELETE requests (statement submission, `stop_statement()`, `delete_statement()`) are deliberately left unretried, since re-issuing them after a connection reset could double-submit or double-mutate state. (#137)
 - The same idempotent GET requests now also retry transient HTTP response statuses (429, 500, 502, 503, 504), not just transport-level exceptions -- a request that reaches Confluent Cloud but gets a momentarily-overloaded gateway response was previously failing on the first such response instead of being retried like a dropped connection. (#140)
-- Increased the default HTTP timeout from 5 to 10s for safety. `connect()` and `Connection.__init__()` no longer accepts explicit `None` for `http_timeout_secs`.
+- Increased the default HTTP timeout from 5 to 10s for safety. `connect()` and `Connection.__init__()` no longer accept explicit `None` for `http_timeout_secs`.
 
 ## 0.4.0, 2026-06-15
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "confluent-sql"
-version = "0.4.0"
+version = "0.4.1"
 description = "DB-API v2 compliant driver for Confluent Cloud Flink SQL"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/confluent_sql/connection.py
+++ b/src/confluent_sql/connection.py
@@ -40,6 +40,11 @@ from .types import PropertiesDict, RowPythonTypes
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_HTTP_TIMEOUT_SECS: float = 10.0
+"""Applied to the httpx client whenever a caller doesn't pass http_timeout_secs explicitly,
+so the effective default is ours to control rather than an implicit dependency on httpx's own
+default (5s)."""
+
 
 def _resolve_api_credentials(
     global_api_key: str | None,
@@ -101,7 +106,7 @@ def connect(  # noqa: PLR0913
     dbname: str | None = None,  # deprecated, use database parameter
     result_page_fetch_pause_millis: int = 100,
     http_user_agent: str | None = None,
-    http_timeout_secs: float | None = None,
+    http_timeout_secs: float = DEFAULT_HTTP_TIMEOUT_SECS,
 ) -> Connection:
     """
     Create a connection to a Confluent SQL service.
@@ -151,8 +156,8 @@ def connect(  # noqa: PLR0913
                        "Confluent-SQL-Dbapi/v<version> (https://confluent.io; support@confluent.io)"
                        where version is from __version__.py
         http_timeout_secs: Timeout in seconds for HTTP requests made by the underlying httpx
-                       client. Must be a positive number. If None (default), the httpx default
-                       of 5 seconds applies to connect, read, write, and pool operations.
+                       client. Must be a positive number. Defaults to DEFAULT_HTTP_TIMEOUT_SECS,
+                       applied to connect, read, write, and pool operations.
 
     Returns:
         A Connection object representing the database connection
@@ -253,7 +258,7 @@ class Connection:
     _database: str | None
     _client: httpx.Client
     _http_user_agent: str
-    _http_timeout_secs: float | None
+    _http_timeout_secs: float
 
     _row_type_registry: RowTypeRegistry
     """Registry for user-defined row types, see register_row_type()."""
@@ -278,7 +283,7 @@ class Connection:
         database: str | None = None,
         statement_results_page_fetch_pause_millis: int = 100,
         http_user_agent: str | None = None,
-        http_timeout_secs: float | None = None,
+        http_timeout_secs: float = DEFAULT_HTTP_TIMEOUT_SECS,
     ):
         """
         Initialize a new connection to a Confluent SQL service.
@@ -317,8 +322,7 @@ class Connection:
                            Defaults to the value of DEFAULT_USER_AGENT, which includes the
                            driver name/version, documentation URL, and support email.
             http_timeout_secs: Timeout in seconds applied to the underlying httpx client.
-                           Must be a positive number. If None (default), the httpx default
-                           of 5 seconds applies.
+                           Must be a positive number. Defaults to DEFAULT_HTTP_TIMEOUT_SECS.
         """
         self.environment_id = environment_id
         # Fold a falsy pool ("" or None) into None so the attribute honestly reports the
@@ -344,20 +348,14 @@ class Connection:
             http_user_agent if http_user_agent is not None else self.DEFAULT_USER_AGENT
         )
 
-        if http_timeout_secs is not None:
-            # Reject bool explicitly: bool is a subclass of int in Python, but a True/False
-            # value here is almost certainly a programming error rather than a valid timeout.
-            if isinstance(http_timeout_secs, bool) or not isinstance(
-                http_timeout_secs, (int, float)
-            ):
-                raise InterfaceError(
-                    f"http_timeout_secs must be a number, "
-                    f"got {type(http_timeout_secs).__name__}"
-                )
-            if http_timeout_secs <= 0:
-                raise InterfaceError(
-                    f"http_timeout_secs must be positive, got {http_timeout_secs}"
-                )
+        # Reject bool explicitly: bool is a subclass of int in Python, but a True/False
+        # value here is almost certainly a programming error rather than a valid timeout.
+        if isinstance(http_timeout_secs, bool) or not isinstance(http_timeout_secs, (int, float)):
+            raise InterfaceError(
+                f"http_timeout_secs must be a number, got {type(http_timeout_secs).__name__}"
+            )
+        if http_timeout_secs <= 0:
+            raise InterfaceError(f"http_timeout_secs must be positive, got {http_timeout_secs}")
         self._http_timeout_secs = http_timeout_secs
 
         if not endpoint and not (cloud_provider and cloud_region):
@@ -391,8 +389,7 @@ class Connection:
                 "User-Agent": self._http_user_agent,
             },
         }
-        if self._http_timeout_secs is not None:
-            client_kwargs["timeout"] = self._http_timeout_secs
+        client_kwargs["timeout"] = self._http_timeout_secs
         self._client = httpx.Client(**client_kwargs)
 
         self._row_type_registry = RowTypeRegistry()
@@ -1071,10 +1068,10 @@ class Connection:
         return self._closed
 
     @property
-    def http_timeout_secs(self) -> float | None:
+    def http_timeout_secs(self) -> float:
         """
-        Get the configured timeout (in seconds) for HTTP requests, or None if the
-        httpx default (5 seconds) is in effect.
+        Get the effective timeout (in seconds) applied to HTTP requests, which is
+        DEFAULT_HTTP_TIMEOUT_SECS unless a value was supplied at construction time.
         """
         return self._http_timeout_secs
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from typing import TypeAlias
 import pytest
 
 from confluent_sql import Connection, connect
+from confluent_sql.connection import DEFAULT_HTTP_TIMEOUT_SECS
 
 
 def pytest_runtest_setup(item):
@@ -61,7 +62,7 @@ def connection_factory() -> Generator[ConnectionFactory, None, None]:
         database: str | None = None,
         result_page_fetch_pause_millis: int = 100,
         http_user_agent: str | None = None,
-        http_timeout_secs: float | None = None,
+        http_timeout_secs: float = DEFAULT_HTTP_TIMEOUT_SECS,
         endpoint: str | None = None,
     ) -> Connection:
         if global_api_key is None:

--- a/tests/unit/test_connection_unit.py
+++ b/tests/unit/test_connection_unit.py
@@ -11,6 +11,7 @@ import pytest
 from confluent_sql import InterfaceError, OperationalError, StatementNotFoundError
 from confluent_sql.__version__ import VERSION
 from confluent_sql.connection import (
+    DEFAULT_HTTP_TIMEOUT_SECS,
     Connection,
     RowTypeRegistry,
     _resolve_api_credentials,
@@ -2415,13 +2416,18 @@ class TestHttpUserAgentProperty:
 class TestHttpTimeoutSecs:
     """Tests for the http_timeout_secs constructor parameter and property."""
 
-    def test_default_is_none_and_httpx_default_applies(
+    def test_default_reports_confluent_sql_default(
         self, invalid_credential_connection: Connection
     ):
-        """When not provided, the property is None and the httpx default (5s) is used."""
-        assert invalid_credential_connection.http_timeout_secs is None
-        # httpx's default Timeout(timeout=5.0) is wrapped in a Timeout object on the client.
-        assert invalid_credential_connection._client.timeout == httpx.Timeout(5.0)
+        """When not provided, the property reports the effective default, not None."""
+        assert invalid_credential_connection.http_timeout_secs == DEFAULT_HTTP_TIMEOUT_SECS
+        assert invalid_credential_connection._client.timeout == httpx.Timeout(
+            DEFAULT_HTTP_TIMEOUT_SECS
+        )
+
+    def test_default_http_timeout_secs_is_ten_seconds(self):
+        """Pin the exact default value so a silent change here doesn't slip by unnoticed."""
+        assert DEFAULT_HTTP_TIMEOUT_SECS == 10.0
 
     @pytest.mark.parametrize("timeout_value", [0.5, 1, 10, 30.0, 120])
     def test_custom_timeout_via_constructor(


### PR DESCRIPTION
* Increase the default HTTP timeout from 5s to 10s, simplifying the implementation in the process.
* Document that `http_timeout_secs` can no longer be passed explicitly None (just leave it at default).
* Stamp 0.4.1 in preparation for making new patch release.