### PR TITLE
[v0.4.x] Snapshot mode GA

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -45,7 +45,7 @@ Every statement progresses through these phases:
 
 ### How Phases Progress
 
-**Snapshot queries (the default):** _(⚠️ [Early Access](https://docs.confluent.io/cloud/current/flink/concepts/snapshot-queries.html))_
+**Snapshot queries (the default):**
 
 ```
 PENDING  → RUNNING → COMPLETED

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this dbapi driver will be documented in this file.
 
+## 0.4.2, 2026-07-17
+
+### Changed
+
+- Snapshot queries on Confluent Cloud Flink SQL are now Generally Available. Removed the Early Access warning previously emitted on first creation of a snapshot-mode cursor, along with the Early Access advisories throughout the documentation (`README.md`, `ARCHITECTURE.md`, `DBAPI_EXTENSIONS.md`, `STREAMING.md`). (#119, #160)
+
 ## 0.4.1, 2026-07-07
 
 ### Fixed

--- a/DBAPI_EXTENSIONS.md
+++ b/DBAPI_EXTENSIONS.md
@@ -4,8 +4,6 @@ The `confluent-sql` driver extends the standard [DB-API v2](https://peps.python.
 
 ## Understanding Snapshot vs Streaming Modes
 
-> **⚠️ Early Access:** [Snapshot queries](https://docs.confluent.io/cloud/current/flink/concepts/snapshot-queries.html) on Confluent Cloud Flink SQL are currently in Early Access and may be subject to change.
-
 **By default, the driver operates in [SNAPSHOT mode](https://docs.confluent.io/cloud/current/flink/concepts/snapshot-queries.html)**, producing behavior very similar to traditional SQL databases:
 
 - Queries execute and block until complete

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is pre-production code mainly developed as the lower level portion of a `db
 
 The behavior of snapshot-mode cursors, complying with dbapi semantics, are well stable. The streaming query extensions are more of a work in progress at this time. Feedback and suggestions are welcome!
 
-> **⚠️ Early Access:** [Snapshot queries](https://docs.confluent.io/cloud/current/flink/concepts/snapshot-queries.html) on Confluent Cloud Flink SQL are currently in Early Access and may be subject to change. You will need to request access to snapshot queries for your organization from Confluent. The driver defaults to snapshot mode for all queries unless streaming mode is explicitly requested.
+The driver defaults to [snapshot mode](https://docs.confluent.io/cloud/current/flink/concepts/snapshot-queries.html) for all queries unless streaming mode is explicitly requested.
 
 ## Prerequisites
 

--- a/STREAMING.md
+++ b/STREAMING.md
@@ -4,8 +4,6 @@ The `confluent-sql` driver provides full support for continuous streaming querie
 
 ## Overview
 
-> **⚠️ Early Access:** [Snapshot queries](https://docs.confluent.io/cloud/current/flink/concepts/snapshot-queries.html) on Confluent Cloud Flink SQL are currently in Early Access and may be subject to change. The SNAPSHOT mode described below relies on this feature.
-
 This driver supports two primary execution modes:
 
 | Mode                   | Use Case              | Query Examples                  | Result Behavior                                                              |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "confluent-sql"
-version = "0.4.1"
+version = "0.4.2"
 description = "DB-API v2 compliant driver for Confluent Cloud Flink SQL"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/confluent_sql/connection.py
+++ b/src/confluent_sql/connection.py
@@ -263,10 +263,6 @@ class Connection:
     _row_type_registry: RowTypeRegistry
     """Registry for user-defined row types, see register_row_type()."""
 
-    _snapshot_warning_issued: bool
-    """Internal flag to track whether the snapshot query early access warning has been issued.
-        Remove after snapshot queries reach open preview (expected May 2026)."""
-
     def __init__(  # noqa: PLR0913
         self,
         environment_id: str,
@@ -394,9 +390,6 @@ class Connection:
 
         self._row_type_registry = RowTypeRegistry()
 
-        # TODO: remove after snapshot queries reach open preview (May 2026)
-        self._snapshot_warning_issued = False
-
     def close(self) -> None:
         """
         Close the connection.
@@ -508,15 +501,6 @@ class Connection:
         """
         if self._closed:
             raise InterfaceError("Connection is closed")
-
-        # TODO: remove after snapshot queries reach open preview (May 2026)
-        if mode.is_snapshot and not self._snapshot_warning_issued:
-            self._snapshot_warning_issued = True
-            warnings.warn(
-                "Snapshot queries on Confluent Cloud Flink SQL are currently in "
-                "Early Access and may be subject to change.",
-                stacklevel=2,
-            )
 
         return Cursor(self, as_dict=as_dict, execution_mode=mode)
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -239,7 +239,6 @@ def mock_connection_factory(mocker, statement_response_factory) -> MockConnectio
         mock_conn.closing_cursor = types.MethodType(Connection.closing_cursor, mock_conn)
 
         mock_conn._row_type_registry = RowTypeRegistry()
-        mock_conn._snapshot_warning_issued = False
 
         return mock_conn
 

--- a/tests/unit/test_cursor_unit.py
+++ b/tests/unit/test_cursor_unit.py
@@ -1,6 +1,5 @@
 import re
 import types
-import warnings
 
 import pytest
 
@@ -1671,63 +1670,6 @@ class TestMayHaveResults:
         mock_reader.may_have_results = True
 
         assert mock_connection_cursor.may_have_results is True
-
-
-@pytest.mark.unit
-class TestSnapshotWarning:
-    """Tests for the early access warning emitted when creating snapshot mode cursors."""
-
-    def test_snapshot_warning_emitted_once_per_connection(self, mock_connection_factory):
-        """Verify that snapshot mode warning is emitted exactly once per connection."""
-        mock_connection = mock_connection_factory(None, None)
-
-        # First snapshot cursor should emit the warning
-        with pytest.warns(
-            UserWarning,
-            match="Snapshot queries on Confluent Cloud Flink SQL are currently in Early Access",
-        ):
-            cursor1 = mock_connection.cursor(mode=ExecutionMode.SNAPSHOT)
-
-        # Flag should now be set
-        assert mock_connection._snapshot_warning_issued is True
-
-        # Second snapshot cursor should NOT emit warning
-        with warnings.catch_warnings(record=True) as warning_list:
-            warnings.simplefilter("always")
-            cursor2 = mock_connection.cursor(mode=ExecutionMode.SNAPSHOT)
-
-        # Filter to only UserWarnings about snapshot
-        snapshot_warnings = [
-            w for w in warning_list
-            if issubclass(w.category, UserWarning)
-            and "Snapshot queries" in str(w.message)
-        ]
-        assert len(snapshot_warnings) == 0
-
-        cursor1.close()
-        cursor2.close()
-
-    def test_snapshot_warning_not_emitted_for_streaming_query_cursor(self, mock_connection_factory):
-        """Verify that warning is not emitted for streaming query cursors."""
-        mock_connection = mock_connection_factory(None, None)
-
-        # Streaming query cursor should not emit warning
-        with warnings.catch_warnings(record=True) as warning_list:
-            warnings.simplefilter("always")
-            cursor = mock_connection.cursor(mode=ExecutionMode.STREAMING_QUERY)
-
-        # Filter to only UserWarnings about snapshot
-        snapshot_warnings = [
-            w for w in warning_list
-            if issubclass(w.category, UserWarning)
-            and "Snapshot queries" in str(w.message)
-        ]
-        assert len(snapshot_warnings) == 0
-
-        # Flag should still be False
-        assert mock_connection._snapshot_warning_issued is False
-
-        cursor.close()
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Cherry-pick c240b5c7ac from main into v0.4.x timeline since snapshot queries have gone GA in Confluent Cloud:
  * Remove warning on first use of snapshot mode statements.
  * Update documentation.

Stamp as version 0.4.2 in pyproject and changelog.