### PR TITLE
Ergonomic statement properties: keys & value enumerations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this dbapi driver will be documented in this file.
 
 ### Added
 
+- New module `confluent_sql.statement_properties` gives statement `SET` options a discoverable,
+  type-checkable face alongside the existing open-ended `PropertiesDict`. `Property` is a `str`
+  enum of the `sql.*` option keys from the [SET-options reference](https://docs.confluent.io/cloud/current/flink/reference/statements/set.html)
+  (e.g. `Property.SNAPSHOT_WRITE_MODE`); `SnapshotWriteMode` (`default`/`fast-write`) and
+  `SnapshotMode` (`now`/`off`) enumerate the fixed value sets, sharing the `PropertyValue` base.
+  Members are `str` instances that compare, hash, JSON-serialize, and stringify as their wire
+  string, so they drop straight into a `properties=` dict with no `.value` unwrapping. `PropertiesDict`
+  now advertises `Property` keys and `PropertyValue` values. (#162)
 - class `Connection` now has methods to enable / inspect / disable [Tableflow](https://www.confluent.io/product/tableflow/) materialization of the Kafka topic backing a Flink table (#117). Tableflow-enabled topics/tables can be snapshot queried in an optimized fashion.
   - `Connection.enable_tableflow(table_name, *, tableflow_formats, storage, config=None, wait_for_running=True, timeout=300)` adds an Iceberg/Delta sink. `tableflow_formats` takes a single `TableFormat` (e.g. `TableFormat.ICEBERG`) or a collection for several; `storage` is one of `ManagedStorage()` (zero-config), `ByobAwsStorage`, or `AzureAdlsStorage`; `config` is an optional `TableflowTopicConfig`. By default it blocks until the topic reaches `RUNNING`; pass `wait_for_running=False` to return as soon as the create is accepted (topic in `PENDING`). Raises `TableflowTopicAlreadyExistsError` if Tableflow is already enabled.
   - `Connection.get_tableflow(table_name)` returns the current `TableflowTopic` (phase, spec, status), raising `TableflowTopicNotFoundError` if Tableflow is not enabled for the topic.

--- a/src/confluent_sql/__init__.py
+++ b/src/confluent_sql/__init__.py
@@ -39,6 +39,7 @@ from .exceptions import (
 from .execution_mode import ExecutionMode
 from .result_readers import ChangeloggedRow
 from .statement import HIDDEN_LABEL, Op
+from .statement_properties import Property, PropertyValue, SnapshotMode, SnapshotWriteMode
 from .tableflow import (
     AzureAdlsStorage,
     ByobAwsStorage,
@@ -106,6 +107,10 @@ __all__ = [
     "threadsafety",
     "paramstyle",
     "PropertiesDict",
+    "Property",
+    "PropertyValue",
+    "SnapshotMode",
+    "SnapshotWriteMode",
     "SqlNone",
     "YearMonthInterval",
     "HIDDEN_LABEL",

--- a/src/confluent_sql/connection.py
+++ b/src/confluent_sql/connection.py
@@ -50,6 +50,7 @@ from .tableflow import (
     build_create_payload,
     normalize_table_formats,
 )
+from .statement_properties import Property, SnapshotMode
 from .types import PropertiesDict, RowPythonTypes, StrAnyDict
 
 logger = logging.getLogger(__name__)
@@ -451,9 +452,9 @@ class Connection:
     """Control-plane base path for the Tableflow-topics resource (enable/get/disable)."""
 
     _RESERVED_STATEMENT_PROPERTIES = {
-        "sql.current-catalog",
-        "sql.current-database",
-        "sql.snapshot.mode",
+        Property.CURRENT_CATALOG,
+        Property.CURRENT_DATABASE,
+        Property.SNAPSHOT_MODE,
     }
     """Per-statement properties the driver owns and overlays itself from connection/execution state
     (the active catalog, database, and snapshot mode). They are not knobs a caller may set, so
@@ -1502,15 +1503,15 @@ class Connection:
             merged_properties.update(properties)
 
         # Connection-level properties overlay (always set, cannot be overridden by user)
-        merged_properties["sql.current-catalog"] = self.environment_id
+        merged_properties[Property.CURRENT_CATALOG] = self.environment_id
 
         if self._database is not None:
-            merged_properties["sql.current-database"] = self._database
+            merged_properties[Property.CURRENT_DATABASE] = self._database
 
         # Cursor-level execution mode properties overlay (always set when applicable)
         if execution_mode.is_snapshot:
             # Ask for snapshot mode behavior -- point-in-time results.
-            merged_properties["sql.snapshot.mode"] = "now"
+            merged_properties[Property.SNAPSHOT_MODE] = SnapshotMode.NOW
 
         return merged_properties
 

--- a/src/confluent_sql/connection.py
+++ b/src/confluent_sql/connection.py
@@ -100,8 +100,7 @@ def _resolve_api_credentials(
         return (flink_key, flink_secret)
 
     raise InterfaceError(
-        "Either global_api_key/global_api_secret or flink_api_key/flink_api_secret "
-        "must be provided"
+        "Either global_api_key/global_api_secret or flink_api_key/flink_api_secret must be provided"
     )
 
 
@@ -135,9 +134,7 @@ def _resolve_tableflow_credentials(
         return (global_key, global_secret)
 
     if bool(tableflow_key) != bool(tableflow_secret):
-        raise InterfaceError(
-            "tableflow_api_key and tableflow_api_secret must be provided together"
-        )
+        raise InterfaceError("tableflow_api_key and tableflow_api_secret must be provided together")
     if tableflow_key:
         return (tableflow_key, tableflow_secret)
     return None
@@ -1337,6 +1334,7 @@ class Connection:
             OperationalError: If the statement transitions to FAILED, or if STOPPED is not reached
                 within the timeout.
         """
+
         def raise_if_failed(candidate: Statement) -> None:
             if candidate.is_failed:
                 raise OperationalError(
@@ -1742,7 +1740,7 @@ class Connection:
             self._wrap_request_error(e)
 
     def _request_get(self, url, **kwargs) -> httpx.Response:
-        """Issue a Flink-gateway GET, retrying transient transport errors (#137) and transient 
+        """Issue a Flink-gateway GET, retrying transient transport errors (#137) and transient
         HTTP status codes alike -- both feed the same call_with_retries backoff/attempt budget. If
         retries are exhausted (or the exception isn't retryable at all), the raw httpx exception
         is translated to OperationalError before it escapes (#138) -- it's never leaked raw.
@@ -1962,9 +1960,7 @@ class Connection:
                 "pair; neither was supplied to connect()."
             )
         if self._controlplane_client is None:
-            self._controlplane_client = self._make_controlplane_client(
-                self._controlplane_auth
-            )
+            self._controlplane_client = self._make_controlplane_client(self._controlplane_auth)
         return self._controlplane_client
 
     def _get_connect_controlplane_client(self) -> httpx.Client:
@@ -2232,6 +2228,7 @@ class Connection:
             OperationalError: If the topic transitions to FAILED (surfacing the error message and
                 failing formats), or if RUNNING is not reached within timeout.
         """
+
         def raise_if_failed(candidate: TableflowTopic) -> None:
             if candidate.phase is TableflowPhase.FAILED:
                 failing = "; ".join(

--- a/src/confluent_sql/connection.py
+++ b/src/confluent_sql/connection.py
@@ -41,6 +41,7 @@ from .retry import (
 )
 from .statement import LABEL_PREFIX as STATEMENT_LABEL_PREFIX
 from .statement import ChangelogRow, Statement
+from .statement_properties import Property, SnapshotMode
 from .tableflow import (
     TableflowPhase,
     TableflowStorage,
@@ -50,7 +51,6 @@ from .tableflow import (
     build_create_payload,
     normalize_table_formats,
 )
-from .statement_properties import Property, SnapshotMode
 from .types import PropertiesDict, RowPythonTypes, StrAnyDict
 
 logger = logging.getLogger(__name__)

--- a/src/confluent_sql/connectors.py
+++ b/src/confluent_sql/connectors.py
@@ -173,9 +173,7 @@ class ConnectorStatus:
                 raw=data,
             )
         except KeyError as e:
-            raise OperationalError(
-                f"Error parsing connector status response, missing {e}."
-            ) from e
+            raise OperationalError(f"Error parsing connector status response, missing {e}.") from e
 
 
 @dataclass
@@ -331,9 +329,7 @@ class ConnectorApi:
         if wait_for_removal:
             self._wait_for_removal(name, timeout)
 
-    def pause(
-        self, name: str, *, wait_for_paused: bool = True, timeout: float = 300
-    ) -> Connector:
+    def pause(self, name: str, *, wait_for_paused: bool = True, timeout: float = 300) -> Connector:
         """Pause a managed connector and, by default, block until it reaches PAUSED.
 
         `PUT .../connectors/{name}/pause`. The action response carries no connector body, so the
@@ -448,6 +444,7 @@ class ConnectorApi:
             OperationalError: If the connector transitions to FAILED (surfacing `connector.trace`),
                 or if `target` is not reached within timeout.
         """
+
         def settled(candidate: Connector) -> Connector | None:
             """Resolve the wait: return the connector once at `target`, raise at FAILED, or None
             while still transient so the caller keeps polling."""

--- a/src/confluent_sql/statement_properties.py
+++ b/src/confluent_sql/statement_properties.py
@@ -1,0 +1,82 @@
+"""Discoverable, type-checkable enumerations of Flink SQL statement properties.
+
+Statement properties are the `SET` options a statement is submitted with (`spec.properties` on the
+wire). Callers can pass raw `str` keys and values, but this module curates the ones worth
+discovering: the property *keys* as `Property`, and the fixed value sets as `PropertyValue`
+subclasses. See the "Available SET options" reference:
+https://docs.confluent.io/cloud/current/flink/reference/statements/set.html
+
+Both `Property` and `PropertyValue` subclass `_PropertyEnum` -- a `(str, Enum)` with `StrEnum`
+string semantics -- rather than `enum.StrEnum`, because the repo floor is Python 3.10 and `StrEnum`
+is 3.11+ (`(str, Enum)` is also the house style: `TableFormat`, `ConnectorState`, `TableflowPhase`).
+Members are genuine `str` instances: they compare and hash as their wire string, so they drop
+straight into `PropertiesDict`, satisfy the `isinstance(v, (str, int, bool))` validation in
+`Connection._resolve_properties`, JSON-serialize to the bare wire string, and (via `_PropertyEnum`)
+stringify to it in logs and error messages too -- all with no `.value` unwrapping at the call site.
+"""
+
+from enum import Enum
+
+
+class _PropertyEnum(str, Enum):
+    """`(str, Enum)` with `enum.StrEnum` string semantics, for the 3.10 floor (StrEnum is 3.11+).
+
+    Plain `(str, Enum)` renders `str(member)`/`f"{member}"` as `"Class.MEMBER"`, so a member
+    interpolated into a log line or error message would leak the Python name instead of the wire
+    string. Delegating `__str__`/`__format__` to `str` -- exactly what CPython's `StrEnum` does --
+    makes a member stringify to its wire value everywhere, not just under `json.dumps`.
+    """
+
+    __str__ = str.__str__
+    __format__ = str.__format__
+
+
+class Property(_PropertyEnum):
+    """A Flink SQL statement property key -- the `sql.*` options from the SET-options reference.
+
+    Only statement-scoped `sql.*` keys are modeled; the `client.*` options from the same reference
+    are gateway/client knobs, not statement properties, so they are deliberately omitted.
+    """
+
+    CURRENT_CATALOG = "sql.current-catalog"
+    CURRENT_DATABASE = "sql.current-database"
+    DRY_RUN = "sql.dry-run"
+    INLINE_RESULT = "sql.inline-result"
+    LOCAL_TIME_ZONE = "sql.local-time-zone"
+    SNAPSHOT_MODE = "sql.snapshot.mode"
+    SNAPSHOT_WRITE_MODE = "sql.snapshot.write-mode"
+    STATE_TTL = "sql.state-ttl"
+    INITIAL_OFFSET_FROM = "sql.tables.initial-offset-from"
+    SCAN_BOUNDED_MODE = "sql.tables.scan.bounded.mode"
+    SCAN_BOUNDED_TIMESTAMP_MILLIS = "sql.tables.scan.bounded.timestamp-millis"
+    SCAN_IDLE_TIMEOUT = "sql.tables.scan.idle-timeout"
+    SCAN_SOURCE_OPERATOR_PARALLELISM = "sql.tables.scan.source-operator-parallelism"
+    SCAN_STARTUP_MODE = "sql.tables.scan.startup.mode"
+    SCAN_STARTUP_SPECIFIC_OFFSETS = "sql.tables.scan.startup.specific-offsets"
+    SCAN_STARTUP_TIMESTAMP_MILLIS = "sql.tables.scan.startup.timestamp-millis"
+    SCAN_WATERMARK_ALIGNMENT_MAX_ALLOWED_DRIFT = (
+        "sql.tables.scan.watermark-alignment.max-allowed-drift"
+    )
+
+
+class PropertyValue(_PropertyEnum):
+    """Common base for enums of a property's fixed, enumerated value set.
+
+    Gives every such value enum one shared identity to test against and lets `StatementProperties`
+    (#163) treat them uniformly. Only properties with a documented fixed value set get a subclass;
+    free-form values (catalog names, time zones, durations) stay plain.
+    """
+
+
+class SnapshotWriteMode(PropertyValue):
+    """Values for `Property.SNAPSHOT_WRITE_MODE` -- the write mode for snapshot queries."""
+
+    DEFAULT = "default"
+    FAST_WRITE = "fast-write"  # disables exactly-once for performance; snapshot mode only
+
+
+class SnapshotMode(PropertyValue):
+    """Values for `Property.SNAPSHOT_MODE` -- whether a statement runs as a snapshot query."""
+
+    NOW = "now"
+    OFF = "off"

--- a/src/confluent_sql/tableflow.py
+++ b/src/confluent_sql/tableflow.py
@@ -359,7 +359,5 @@ class TableflowTopic:
             status = TableflowTopicStatus.from_response(response["status"])
             metadata = response.get("metadata", {})
         except KeyError as e:
-            raise OperationalError(
-                f"Error parsing Tableflow topic response, missing {e}."
-            ) from e
+            raise OperationalError(f"Error parsing Tableflow topic response, missing {e}.") from e
         return cls(spec=spec, status=status, metadata=metadata)

--- a/src/confluent_sql/types.py
+++ b/src/confluent_sql/types.py
@@ -525,9 +525,9 @@ class SqlNone:
             # Strip trailing "NOT NULL" constraint if present (case-insensitive).
             # This assists integrations (like dbt adapters) that may provide
             # type names with nullability constraints from schema metadata.
-            python_or_flink_type = (
-                SqlNone._not_null_suffix_regex.sub("", python_or_flink_type).rstrip()
-            )
+            python_or_flink_type = SqlNone._not_null_suffix_regex.sub(
+                "", python_or_flink_type
+            ).rstrip()
 
             # Validate the provided Flink type name using case-insensitive regexes.
 

--- a/src/confluent_sql/types.py
+++ b/src/confluent_sql/types.py
@@ -14,6 +14,7 @@ from types import NoneType
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, Protocol, TypeAlias, TypeVar
 
 from confluent_sql.exceptions import InterfaceError, TypeMismatchError
+from confluent_sql.statement_properties import Property, PropertyValue
 
 if TYPE_CHECKING:
     from .connection import Connection
@@ -61,9 +62,11 @@ nested row types.
 
 StrAnyDict: TypeAlias = dict[str, Any]
 
-PropertiesDict: TypeAlias = dict[str, str | int | bool]
-"""Type for statement properties dictionary. Keys are property names, values can be
-strings, integers, or booleans."""
+PropertiesDict: TypeAlias = dict[str | Property, str | int | bool | PropertyValue]
+"""Type for a statement properties dictionary. Keys are property names -- a raw str or a
+`Property` member; values are str/int/bool or a `PropertyValue` member. The enum arms are
+redundant to the type checker (both subclass str) but document the discoverable options and
+enable autocomplete."""
 
 
 @dataclass

--- a/tests/integration/test_fetch.py
+++ b/tests/integration/test_fetch.py
@@ -176,9 +176,7 @@ class TestCursorFetch:
                 "double_value": 191.2342342,
                 "date_value": date(2024, 6, 15),
                 "time_value": time(12, 34, 56),
-                "time_value_micro": time(
-                    12, 34, 56, 789000
-                ),
+                "time_value_micro": time(12, 34, 56, 789000),
                 "timestamp_value": datetime(2025, 6, 15, 12, 34, 56),  # No micros to lose here.
                 "timestamp_value_micros": datetime(2024, 6, 15, 12, 34, 56, 123456),
                 # GMT+02:00 gets converted to UTC time in the round trip, so comes
@@ -656,9 +654,7 @@ class TestExecuteDDL:
                 with suppress(Exception):
                     connection.delete_statement(statement)
 
-    def test_ctas_statement_properties(
-        self, connection: Connection, auto_dropped_table_name: str
-    ):
+    def test_ctas_statement_properties(self, connection: Connection, auto_dropped_table_name: str):
         """Prove that CTAS statement is DDL but not pure DDL, with no schema.
 
         CTAS (CREATE TABLE AS SELECT) is a hybrid DDL:

--- a/tests/integration/test_tableflow.py
+++ b/tests/integration/test_tableflow.py
@@ -60,9 +60,7 @@ def _tableflow_connection_from_env() -> Connection:
     # organization_id is inferable from a global key (#132), so it's only required outright when
     # no global key is configured.
     org_ok = has_global or bool(organization_id)
-    base_ok = all(
-        [environment_id, org_ok, cloud_provider, cloud_region, database, compute_pool_id]
-    )
+    base_ok = all([environment_id, org_ok, cloud_provider, cloud_region, database, compute_pool_id])
     if not (no_half_pairs and flink_auth_ok and controlplane_ok and cluster_ok and base_ok):
         pytest.skip("Missing environment variables for a Tableflow-capable integration connection")
 
@@ -123,9 +121,7 @@ class TestTableflowLifecycle:
         table = tableflow_table_name
 
         # Create the Flink table (and its backing Kafka topic) Tableflow will materialize.
-        conn.execute_snapshot_ddl(
-            f"CREATE TABLE `{table}` (id INT, description STRING)"
-        )
+        conn.execute_snapshot_ddl(f"CREATE TABLE `{table}` (id INT, description STRING)")
 
         tableflow_enabled = False
         try:

--- a/tests/unit/test_connection_unit.py
+++ b/tests/unit/test_connection_unit.py
@@ -416,9 +416,7 @@ class TestConnectionStopStatement:
         )
 
         with pytest.raises(OperationalError, match="did not reach STOPPED within"):
-            invalid_credential_connection.stop_statement(
-                "stmt-1", wait_for_stopped=True, timeout=0
-            )
+            invalid_credential_connection.stop_statement("stmt-1", wait_for_stopped=True, timeout=0)
 
     def test_blocking_failed_raises(
         self,
@@ -705,9 +703,7 @@ class TestConnectChecks:
         Flink client's base_url and the statement-create payload reflect the discovered org."""
         mock_response = mocker.Mock()
         mock_response.json.return_value = {"data": [{"id": "org-99"}], "metadata": {}}
-        mocker.patch.object(
-            Connection, "_organization_lookup_request", return_value=mock_response
-        )
+        mocker.patch.object(Connection, "_organization_lookup_request", return_value=mock_response)
 
         conn = connect(
             environment_id="env-id",
@@ -836,9 +832,7 @@ class TestConnectChecks:
                 flink_api_secret="",
             )
 
-    def test_half_flink_pair_raises_through_connect(
-        self, connection_factory: ConnectionFactory
-    ):
+    def test_half_flink_pair_raises_through_connect(self, connection_factory: ConnectionFactory):
         """A lone flink_api_key (no secret) raises the half-pair error end-to-end (#112)."""
         with pytest.raises(
             InterfaceError,
@@ -2695,9 +2689,7 @@ class TestHttpUserAgentProperty:
 class TestHttpTimeoutSecs:
     """Tests for the http_timeout_secs constructor parameter and property."""
 
-    def test_default_reports_confluent_sql_default(
-        self, invalid_credential_connection: Connection
-    ):
+    def test_default_reports_confluent_sql_default(self, invalid_credential_connection: Connection):
         """When not provided, the property reports the effective default, not None."""
         assert invalid_credential_connection.http_timeout_secs == DEFAULT_HTTP_TIMEOUT_SECS
         assert invalid_credential_connection._get_flink_client().timeout == httpx.Timeout(
@@ -2788,9 +2780,7 @@ class TestHttpTimeoutSecs:
 class TestComputePoolIdParameter:
     """Test the compute_pool_id parameter for Connection methods."""
 
-    def test_execute_statement_with_compute_pool_id(
-        self, invalid_credential_connection, mocker
-    ):
+    def test_execute_statement_with_compute_pool_id(self, invalid_credential_connection, mocker):
         """Test that _execute_statement uses provided compute_pool_id and logs override."""
         # Mock the HTTP request
         mock_response = mocker.Mock()
@@ -2799,9 +2789,7 @@ class TestComputePoolIdParameter:
             "spec": {"compute_pool_id": "lfcp-custom-pool"},
         }
         mocker.patch.object(
-            invalid_credential_connection._get_flink_client(),
-            'request',
-            return_value=mock_response
+            invalid_credential_connection._get_flink_client(), "request", return_value=mock_response
         )
 
         # Patch logger.info to verify override message
@@ -2809,25 +2797,22 @@ class TestComputePoolIdParameter:
 
         # Call _execute_statement with a custom compute_pool_id
         invalid_credential_connection._execute_statement(
-            "SELECT 1",
-            ExecutionMode.SNAPSHOT,
-            compute_pool_id="lfcp-custom-pool"
+            "SELECT 1", ExecutionMode.SNAPSHOT, compute_pool_id="lfcp-custom-pool"
         )
 
         # Verify the request was made
         invalid_credential_connection._get_flink_client().request.assert_called_once()
         call_kwargs = invalid_credential_connection._get_flink_client().request.call_args
-        payload = call_kwargs.kwargs['json']
+        payload = call_kwargs.kwargs["json"]
 
         # Verify the compute_pool_id in the payload matches the provided one
-        assert payload['spec']['compute_pool_id'] == "lfcp-custom-pool"
+        assert payload["spec"]["compute_pool_id"] == "lfcp-custom-pool"
 
         # Verify logger.info was called with the override message
         assert mock_log_info.called, "Expected logger.info to be called"
         log_messages = [str(call) for call in mock_log_info.call_args_list]
         assert any(
-            "Overriding connection compute_pool_id" in msg
-            and "lfcp-custom-pool" in msg
+            "Overriding connection compute_pool_id" in msg and "lfcp-custom-pool" in msg
             for msg in log_messages
         ), f"Expected override log message not found in: {log_messages}"
 
@@ -2842,25 +2827,18 @@ class TestComputePoolIdParameter:
             "spec": {"compute_pool_id": "cp-id"},
         }
         mocker.patch.object(
-            invalid_credential_connection._get_flink_client(),
-            'request',
-            return_value=mock_response
+            invalid_credential_connection._get_flink_client(), "request", return_value=mock_response
         )
 
         # Call _execute_statement without compute_pool_id
-        invalid_credential_connection._execute_statement(
-            "SELECT 1",
-            ExecutionMode.SNAPSHOT
-        )
+        invalid_credential_connection._execute_statement("SELECT 1", ExecutionMode.SNAPSHOT)
 
         # Verify the payload uses the connection's compute_pool_id
         call_kwargs = invalid_credential_connection._get_flink_client().request.call_args
-        payload = call_kwargs.kwargs['json']
-        assert payload['spec']['compute_pool_id'] == "cp-id"  # from fixture
+        payload = call_kwargs.kwargs["json"]
+        assert payload["spec"]["compute_pool_id"] == "cp-id"  # from fixture
 
-    def test_execute_statement_omits_pool_when_none_resolved(
-        self, poolless_connection, mocker
-    ):
+    def test_execute_statement_omits_pool_when_none_resolved(self, poolless_connection, mocker):
         """With no per-call argument and no connection default, spec carries no pool."""
         mock_response = mocker.Mock()
         mock_response.json.return_value = {"name": "test-statement", "spec": {}}
@@ -2876,9 +2854,9 @@ class TestComputePoolIdParameter:
 
         # No connection default means there is nothing to "override" -- stay silent.
         log_messages = [str(call) for call in mock_log_info.call_args_list]
-        assert not any(
-            "Overriding connection compute_pool_id" in msg for msg in log_messages
-        ), f"Override log should not fire without a connection default: {log_messages}"
+        assert not any("Overriding connection compute_pool_id" in msg for msg in log_messages), (
+            f"Override log should not fire without a connection default: {log_messages}"
+        )
 
     def test_execute_statement_per_call_pool_without_connection_default(
         self, poolless_connection, mocker
@@ -2902,9 +2880,9 @@ class TestComputePoolIdParameter:
         assert payload["spec"]["compute_pool_id"] == "lfcp-explicit"
 
         log_messages = [str(call) for call in mock_log_info.call_args_list]
-        assert not any(
-            "Overriding connection compute_pool_id" in msg for msg in log_messages
-        ), f"Override log should not fire without a connection default: {log_messages}"
+        assert not any("Overriding connection compute_pool_id" in msg for msg in log_messages), (
+            f"Override log should not fire without a connection default: {log_messages}"
+        )
 
     @pytest.mark.parametrize("falsy_per_call_pool", [None, ""])
     def test_execute_statement_falsy_per_call_pool_defers_to_default(
@@ -2934,42 +2912,37 @@ class TestComputePoolIdParameter:
         assert payload["spec"]["compute_pool_id"] == "cp-id"  # the connection default
 
         log_messages = [str(call) for call in mock_log_info.call_args_list]
-        assert not any(
-            "Overriding connection compute_pool_id" in msg for msg in log_messages
-        ), f"Falsy per-call pool should not fire the override log: {log_messages}"
+        assert not any("Overriding connection compute_pool_id" in msg for msg in log_messages), (
+            f"Falsy per-call pool should not fire the override log: {log_messages}"
+        )
 
-    def test_execute_statement_validates_compute_pool_type(
-        self, invalid_credential_connection
-    ):
+    def test_execute_statement_validates_compute_pool_type(self, invalid_credential_connection):
         """Test that invalid compute_pool_id type raises InterfaceError."""
         with pytest.raises(InterfaceError, match="compute_pool_id must be a string"):
             invalid_credential_connection._execute_statement(
                 "SELECT 1",
                 ExecutionMode.SNAPSHOT,
-                compute_pool_id=12345  # Invalid: int instead of str
+                compute_pool_id=12345,  # Invalid: int instead of str
             )
 
-    def test_execute_snapshot_ddl_with_compute_pool_id(
-        self, invalid_credential_connection, mocker
-    ):
+    def test_execute_snapshot_ddl_with_compute_pool_id(self, invalid_credential_connection, mocker):
         """Test that execute_snapshot_ddl passes compute_pool_id to cursor.execute."""
         # Mock the cursor and its execute method
         mock_cursor = mocker.Mock()
         mocker.patch.object(
             invalid_credential_connection,
-            'closing_cursor',
-            return_value=mocker.MagicMock(__enter__=mocker.Mock(return_value=mock_cursor))
+            "closing_cursor",
+            return_value=mocker.MagicMock(__enter__=mocker.Mock(return_value=mock_cursor)),
         )
 
         invalid_credential_connection.execute_snapshot_ddl(
-            "CREATE TABLE foo (id INT)",
-            compute_pool_id="lfcp-custom-pool"
+            "CREATE TABLE foo (id INT)", compute_pool_id="lfcp-custom-pool"
         )
 
         # Verify cursor.execute was called with compute_pool_id
         mock_cursor.execute.assert_called_once()
         call_kwargs = mock_cursor.execute.call_args.kwargs
-        assert call_kwargs['compute_pool_id'] == "lfcp-custom-pool"
+        assert call_kwargs["compute_pool_id"] == "lfcp-custom-pool"
 
     def test_execute_streaming_ddl_with_compute_pool_id(
         self, invalid_credential_connection, mocker
@@ -2979,16 +2952,16 @@ class TestComputePoolIdParameter:
         mock_cursor = mocker.Mock()
         mocker.patch.object(
             invalid_credential_connection,
-            'closing_cursor',
-            return_value=mocker.MagicMock(__enter__=mocker.Mock(return_value=mock_cursor))
+            "closing_cursor",
+            return_value=mocker.MagicMock(__enter__=mocker.Mock(return_value=mock_cursor)),
         )
 
         invalid_credential_connection.execute_streaming_ddl(
             "CREATE MATERIALIZED TABLE foo AS SELECT * FROM bar",
-            compute_pool_id="lfcp-streaming-pool"
+            compute_pool_id="lfcp-streaming-pool",
         )
 
         # Verify cursor.execute was called with compute_pool_id
         mock_cursor.execute.assert_called_once()
         call_kwargs = mock_cursor.execute.call_args.kwargs
-        assert call_kwargs['compute_pool_id'] == "lfcp-streaming-pool"
+        assert call_kwargs["compute_pool_id"] == "lfcp-streaming-pool"

--- a/tests/unit/test_connection_unit_properties.py
+++ b/tests/unit/test_connection_unit_properties.py
@@ -241,9 +241,7 @@ class TestExecuteStatementProperties:
         naming the wire key -- pins the enum/reserved-set interop the connection.py adoption relies
         on (enum members hash and compare as their wire string)."""
 
-        with pytest.raises(
-            InterfaceError, match=f"'{wire_key}' is a reserved system property"
-        ):
+        with pytest.raises(InterfaceError, match=f"'{wire_key}' is a reserved system property"):
             invalid_credential_connection._execute_statement(
                 "SELECT 1",
                 ExecutionMode.SNAPSHOT,

--- a/tests/unit/test_connection_unit_properties.py
+++ b/tests/unit/test_connection_unit_properties.py
@@ -1,5 +1,6 @@
 """Unit tests for statement properties parameter support (Issue #68)."""
 
+import json
 from unittest.mock import Mock
 
 import pytest
@@ -7,6 +8,7 @@ import pytest
 from confluent_sql import InterfaceError, connect
 from confluent_sql.connection import Connection
 from confluent_sql.execution_mode import ExecutionMode
+from confluent_sql.statement_properties import Property, SnapshotWriteMode
 
 
 @pytest.fixture()
@@ -162,6 +164,29 @@ class TestExecuteStatementProperties:
         assert "sql.current-catalog" in props
         assert "sql.snapshot.mode" in props
 
+    def test_properties_enum_key_and_value_reach_wire_as_strings(
+        self, invalid_credential_connection, mocker
+    ):
+        """A bare Property key and PropertyValue value survive _resolve_properties and serialize to
+        their wire strings -- guards the public #162 promise (enum members are usable directly in
+        properties=) against a future normalization/re-validation step in the merge dropping or
+        mangling them. Wire strings are asserted as literals, independent of the enums under
+        test."""
+        request_mock = self.install_request_mock(invalid_credential_connection, mocker)
+
+        invalid_credential_connection._execute_statement(
+            "SELECT 1",
+            ExecutionMode.SNAPSHOT,
+            properties={Property.SNAPSHOT_WRITE_MODE: SnapshotWriteMode.FAST_WRITE},
+        )
+
+        payload = request_mock.call_args[1]["json"]
+        # Present under the wire-string key with the wire-string value, though keyed by an enum.
+        assert payload["spec"]["properties"]["sql.snapshot.write-mode"] == "fast-write"
+        # ...and it round-trips through JSON as a bare string, not an enum repr.
+        serialized = json.loads(json.dumps(payload))
+        assert serialized["spec"]["properties"]["sql.snapshot.write-mode"] == "fast-write"
+
     def test_properties_streaming_mode_no_snapshot(self, invalid_credential_connection, mocker):
         """Verify snapshot.mode is not set in streaming mode."""
         request_mock = self.install_request_mock(invalid_credential_connection, mocker)
@@ -199,4 +224,28 @@ class TestExecuteStatementProperties:
                 "SELECT 1",
                 ExecutionMode.SNAPSHOT,
                 properties={reserved_property: "user-value"},
+            )
+
+    @pytest.mark.parametrize(
+        ("reserved_member", "wire_key"),
+        [
+            (Property.CURRENT_CATALOG, "sql.current-catalog"),
+            (Property.CURRENT_DATABASE, "sql.current-database"),
+            (Property.SNAPSHOT_MODE, "sql.snapshot.mode"),
+        ],
+    )
+    def test_properties_rejects_reserved_property_passed_as_enum_member(
+        self, invalid_credential_connection, reserved_member, wire_key
+    ):
+        """A reserved key supplied as a Property member is rejected identically to its raw string,
+        naming the wire key -- pins the enum/reserved-set interop the connection.py adoption relies
+        on (enum members hash and compare as their wire string)."""
+
+        with pytest.raises(
+            InterfaceError, match=f"'{wire_key}' is a reserved system property"
+        ):
+            invalid_credential_connection._execute_statement(
+                "SELECT 1",
+                ExecutionMode.SNAPSHOT,
+                properties={reserved_member: "user-value"},
             )

--- a/tests/unit/test_connectors_connection_unit.py
+++ b/tests/unit/test_connectors_connection_unit.py
@@ -156,9 +156,7 @@ class TestConnectorApiCreate:
         ctx.queue("status", _ok_response(_status_body("PROVISIONING")))
         api = ConnectorApi(ctx)
 
-        connector = api.create(
-            "MyDatagen", config=_create_config(), wait_for_running=False
-        )
+        connector = api.create("MyDatagen", config=_create_config(), wait_for_running=False)
 
         assert connector.state is ConnectorState.PROVISIONING
         assert ctx.count("status") == 1

--- a/tests/unit/test_cursor_unit.py
+++ b/tests/unit/test_cursor_unit.py
@@ -1575,9 +1575,7 @@ class TestMayHaveResults:
         """Test that may_have_results propagates InterfaceError from has_schema()."""
         # Mock a statement where has_schema() raises (e.g., FAILED statement)
         mock_statement = mocker.Mock()
-        mock_statement.has_schema.side_effect = InterfaceError(
-            "Statement traits are not available"
-        )
+        mock_statement.has_schema.side_effect = InterfaceError("Statement traits are not available")
         mock_connection_cursor._statement = mock_statement
 
         # may_have_results should propagate the exception
@@ -1685,15 +1683,12 @@ class TestComputePoolIdParameter:
         mock_execute = mocker.Mock(side_effect=original_method)
         mock_connection_cursor._connection._execute_statement = mock_execute
 
-        mock_connection_cursor.execute(
-            "SELECT 1",
-            compute_pool_id="lfcp-test-pool"
-        )
+        mock_connection_cursor.execute("SELECT 1", compute_pool_id="lfcp-test-pool")
 
         # Verify _execute_statement was called with the compute_pool_id
         mock_execute.assert_called_once()
         call_kwargs = mock_execute.call_args.kwargs
-        assert call_kwargs['compute_pool_id'] == "lfcp-test-pool"
+        assert call_kwargs["compute_pool_id"] == "lfcp-test-pool"
 
     def test_cursor_execute_defaults_to_none_when_not_provided(
         self, mock_connection_cursor: Cursor, mocker
@@ -1710,7 +1705,7 @@ class TestComputePoolIdParameter:
 
         # Should be called with None, which triggers default behavior in _execute_statement
         call_kwargs = mock_execute.call_args.kwargs
-        assert call_kwargs.get('compute_pool_id') is None
+        assert call_kwargs.get("compute_pool_id") is None
 
     def test_cursor_submit_statement_passes_compute_pool_id(
         self, mock_connection_cursor: Cursor, mocker
@@ -1723,25 +1718,18 @@ class TestComputePoolIdParameter:
         mock_execute = mocker.Mock(side_effect=original_method)
         mock_connection_cursor._connection._execute_statement = mock_execute
 
-        mock_connection_cursor._submit_statement(
-            "SELECT 1",
-            compute_pool_id="lfcp-custom-pool"
-        )
+        mock_connection_cursor._submit_statement("SELECT 1", compute_pool_id="lfcp-custom-pool")
 
         call_kwargs = mock_execute.call_args.kwargs
-        assert call_kwargs['compute_pool_id'] == "lfcp-custom-pool"
+        assert call_kwargs["compute_pool_id"] == "lfcp-custom-pool"
 
-    def test_cursor_execute_rejects_non_string_compute_pool_id(
-        self, mock_connection_factory
-    ):
+    def test_cursor_execute_rejects_non_string_compute_pool_id(self, mock_connection_factory):
         """Test that Cursor.execute() rejects non-string compute_pool_id values."""
         # Create a mock connection but bind the REAL _execute_statement method
         # so that validation logic runs
         mock_conn = mock_connection_factory(None, None)
         # Replace the mocked _execute_statement with the real one
-        mock_conn._execute_statement = types.MethodType(
-            Connection._execute_statement, mock_conn
-        )
+        mock_conn._execute_statement = types.MethodType(Connection._execute_statement, mock_conn)
 
         with (
             mock_conn.closing_cursor() as cursor,
@@ -1749,7 +1737,7 @@ class TestComputePoolIdParameter:
         ):
             cursor.execute(
                 "SELECT 1",
-                compute_pool_id=12345  # Invalid: int instead of str
+                compute_pool_id=12345,  # Invalid: int instead of str
             )
 
 

--- a/tests/unit/test_statement_properties_unit.py
+++ b/tests/unit/test_statement_properties_unit.py
@@ -1,0 +1,110 @@
+"""Unit tests for the statement_properties enumerations (Issue #162)."""
+
+import json
+
+import pytest
+
+import confluent_sql
+from confluent_sql.statement_properties import (
+    Property,
+    PropertyValue,
+    SnapshotMode,
+    SnapshotWriteMode,
+)
+
+# Every sql.* statement key from the "Available SET options" table, verbatim off the wire.
+# (The client.* options are gateway/client knobs, not statement properties, and are excluded.)
+EXPECTED_PROPERTY_KEYS = {
+    "sql.current-catalog",
+    "sql.current-database",
+    "sql.dry-run",
+    "sql.inline-result",
+    "sql.local-time-zone",
+    "sql.snapshot.mode",
+    "sql.snapshot.write-mode",
+    "sql.state-ttl",
+    "sql.tables.initial-offset-from",
+    "sql.tables.scan.bounded.mode",
+    "sql.tables.scan.bounded.timestamp-millis",
+    "sql.tables.scan.idle-timeout",
+    "sql.tables.scan.source-operator-parallelism",
+    "sql.tables.scan.startup.mode",
+    "sql.tables.scan.startup.specific-offsets",
+    "sql.tables.scan.startup.timestamp-millis",
+    "sql.tables.scan.watermark-alignment.max-allowed-drift",
+}
+
+
+@pytest.mark.unit
+class TestProperty:
+    """The Property key enum: exact wire strings and complete, drift-proof membership."""
+
+    def test_property_key_set_is_exactly_the_documented_sql_options(self):
+        """Property must name every sql.* SET option and no extras -- catches add/drop drift."""
+        assert {member.value for member in Property} == EXPECTED_PROPERTY_KEYS
+
+    @pytest.mark.parametrize(
+        ("member", "wire_key"),
+        [
+            (Property.CURRENT_CATALOG, "sql.current-catalog"),
+            (Property.CURRENT_DATABASE, "sql.current-database"),
+            (Property.SNAPSHOT_MODE, "sql.snapshot.mode"),
+            (Property.SNAPSHOT_WRITE_MODE, "sql.snapshot.write-mode"),
+            (Property.STATE_TTL, "sql.state-ttl"),
+            (Property.LOCAL_TIME_ZONE, "sql.local-time-zone"),
+            (Property.SCAN_STARTUP_MODE, "sql.tables.scan.startup.mode"),
+        ],
+    )
+    def test_property_member_pins_exact_wire_key(self, member, wire_key):
+        """A Property member's value and its str-equality both equal the wire key exactly."""
+        assert member.value == wire_key
+        assert member == wire_key
+
+    def test_property_member_is_a_plain_str(self):
+        """Property members are str subclass instances, so they drop into PropertiesDict/JSON."""
+        assert isinstance(Property.SNAPSHOT_WRITE_MODE, str)
+
+    def test_property_member_stringifies_to_wire_key_not_python_name(self):
+        """str()/f-string of a member yields the wire key, not 'Property.SNAPSHOT_MODE' --
+        so a member interpolated into a log line or error message reads correctly."""
+        assert str(Property.SNAPSHOT_MODE) == "sql.snapshot.mode"
+        assert f"{Property.SNAPSHOT_MODE}" == "sql.snapshot.mode"
+
+
+@pytest.mark.unit
+class TestPropertyValues:
+    """The value enums: exact wire values, a shared PropertyValue base, and bare-member JSON."""
+
+    @pytest.mark.parametrize(
+        ("member", "wire_value"),
+        [
+            (SnapshotWriteMode.DEFAULT, "default"),
+            (SnapshotWriteMode.FAST_WRITE, "fast-write"),
+            (SnapshotMode.NOW, "now"),
+            (SnapshotMode.OFF, "off"),
+        ],
+    )
+    def test_value_member_pins_exact_wire_value(self, member, wire_value):
+        """Each value enum member's value and str-equality both equal the wire value exactly."""
+        assert member.value == wire_value
+        assert member == wire_value
+
+    @pytest.mark.parametrize("value_enum", [SnapshotWriteMode, SnapshotMode])
+    def test_value_enums_share_property_value_base(self, value_enum):
+        """Every value enum derives from PropertyValue, the common statement-property-value base."""
+        assert issubclass(value_enum, PropertyValue)
+
+    def test_bare_members_json_serialize_to_wire_strings(self):
+        """A dict keyed/valued by bare enum members serializes to the exact wire JSON --
+        no .value unwrapping required by callers."""
+        payload = {Property.STATE_TTL: SnapshotWriteMode.FAST_WRITE}
+        assert json.loads(json.dumps(payload)) == {"sql.state-ttl": "fast-write"}
+
+
+@pytest.mark.unit
+def test_enums_are_reexported_from_package_root():
+    """Property, PropertyValue, and the value enums are importable straight off confluent_sql."""
+    assert confluent_sql.Property is Property
+    assert confluent_sql.PropertyValue is PropertyValue
+    assert confluent_sql.SnapshotWriteMode is SnapshotWriteMode
+    assert confluent_sql.SnapshotMode is SnapshotMode

--- a/tests/unit/test_statement_properties_unit.py
+++ b/tests/unit/test_statement_properties_unit.py
@@ -97,8 +97,8 @@ class TestPropertyValues:
     def test_bare_members_json_serialize_to_wire_strings(self):
         """A dict keyed/valued by bare enum members serializes to the exact wire JSON --
         no .value unwrapping required by callers."""
-        payload = {Property.STATE_TTL: SnapshotWriteMode.FAST_WRITE}
-        assert json.loads(json.dumps(payload)) == {"sql.state-ttl": "fast-write"}
+        payload = {Property.SNAPSHOT_WRITE_MODE: SnapshotWriteMode.FAST_WRITE}
+        assert json.loads(json.dumps(payload)) == {"sql.snapshot.write-mode": "fast-write"}
 
 
 @pytest.mark.unit

--- a/tests/unit/test_statement_unit.py
+++ b/tests/unit/test_statement_unit.py
@@ -250,9 +250,7 @@ class TestStatementProperties:
         self, mock_connection: Connection, statement_response_factory: StatementResponseFactory
     ):
         """Test that is_ddl() returns True for impure DDL (CTAS)."""
-        statement_json = statement_response_factory(
-            sql_kind="CREATE_TABLE_AS", null_schema=True
-        )
+        statement_json = statement_response_factory(sql_kind="CREATE_TABLE_AS", null_schema=True)
         statement = Statement.from_response(mock_connection, statement_json)
         assert statement.is_ddl is True
         assert statement.has_schema() is False  # CTAS has no schema
@@ -269,9 +267,7 @@ class TestStatementProperties:
         self, mock_connection: Connection, statement_response_factory: StatementResponseFactory
     ):
         """Test that has_schema() returns False for CTAS statements."""
-        statement_json = statement_response_factory(
-            sql_kind="CREATE_TABLE_AS", null_schema=True
-        )
+        statement_json = statement_response_factory(sql_kind="CREATE_TABLE_AS", null_schema=True)
         statement = Statement.from_response(mock_connection, statement_json)
         assert statement.has_schema() is False
         assert statement.schema is None
@@ -280,9 +276,7 @@ class TestStatementProperties:
         self, mock_connection: Connection, statement_response_factory: StatementResponseFactory
     ):
         """Test that CTAS is DDL but not pure DDL (impure DDL that can stream)."""
-        statement_json = statement_response_factory(
-            sql_kind="CREATE_TABLE_AS", null_schema=True
-        )
+        statement_json = statement_response_factory(sql_kind="CREATE_TABLE_AS", null_schema=True)
         statement = Statement.from_response(mock_connection, statement_json)
 
         # CTAS is impure DDL: is_ddl=True, is_pure_ddl=False

--- a/tests/unit/test_tableflow_connection_unit.py
+++ b/tests/unit/test_tableflow_connection_unit.py
@@ -187,9 +187,7 @@ class TestResolveKafkaClusterId:
 
     def test_seeded_id_skips_cmk(self) -> None:
         conn = _connect(database_kafka_cluster_id="lkc-seed")
-        conn._cmk_request = Mock(
-            side_effect=AssertionError("CMK must not be called")
-        )
+        conn._cmk_request = Mock(side_effect=AssertionError("CMK must not be called"))
         assert conn._resolve_kafka_cluster_id() == "lkc-seed"
 
     def test_lookup_single_match_and_caches(self) -> None:
@@ -204,9 +202,7 @@ class TestResolveKafkaClusterId:
 
     def test_zero_match_raises(self) -> None:
         conn = _connect(global_api_key="gk", global_api_secret="gs", database="Missing")
-        conn._cmk_request = Mock(
-            return_value=_ok_response({"data": [], "metadata": {}})
-        )
+        conn._cmk_request = Mock(return_value=_ok_response({"data": [], "metadata": {}}))
         with pytest.raises(OperationalError, match="No Kafka cluster named 'Missing'"):
             conn._resolve_kafka_cluster_id()
 
@@ -310,9 +306,7 @@ class TestEnableTableflow:
 
     def test_posts_expected_body(self) -> None:
         conn = _connect(database_kafka_cluster_id="lkc-1")
-        conn._tableflow_request = Mock(
-            return_value=_ok_response(_topic_body(), status_code=202)
-        )
+        conn._tableflow_request = Mock(return_value=_ok_response(_topic_body(), status_code=202))
         topic = conn.enable_tableflow(
             "orders",
             tableflow_formats=TableFormat.ICEBERG,
@@ -330,9 +324,7 @@ class TestEnableTableflow:
 
     def test_both_formats_collection_reaches_body(self) -> None:
         conn = _connect(database_kafka_cluster_id="lkc-1")
-        conn._tableflow_request = Mock(
-            return_value=_ok_response(_topic_body(), status_code=202)
-        )
+        conn._tableflow_request = Mock(return_value=_ok_response(_topic_body(), status_code=202))
         conn.enable_tableflow(
             "orders",
             tableflow_formats={TableFormat.DELTA, TableFormat.ICEBERG},
@@ -354,9 +346,7 @@ class TestEnableTableflow:
     def test_blocks_for_running_by_default(self, mocker) -> None:
         # No wait_for_running argument -> default (True) must poll to RUNNING, not return PENDING.
         conn = _connect(database_kafka_cluster_id="lkc-1")
-        conn._tableflow_request = Mock(
-            return_value=_ok_response(_topic_body(), status_code=202)
-        )
+        conn._tableflow_request = Mock(return_value=_ok_response(_topic_body(), status_code=202))
         mocker.patch("confluent_sql.connection.sleep_with_backoff", return_value=iter([None]))
         conn.get_tableflow = Mock(  # type: ignore[method-assign]
             return_value=TableflowTopic.from_response(_topic_body(phase="RUNNING"))
@@ -369,9 +359,7 @@ class TestEnableTableflow:
 
     def test_wait_for_running_polls_to_running(self, mocker) -> None:
         conn = _connect(database_kafka_cluster_id="lkc-1")
-        conn._tableflow_request = Mock(
-            return_value=_ok_response(_topic_body(), status_code=202)
-        )
+        conn._tableflow_request = Mock(return_value=_ok_response(_topic_body(), status_code=202))
         mocker.patch("confluent_sql.connection.sleep_with_backoff", return_value=iter([None]))
         conn.get_tableflow = Mock(  # type: ignore[method-assign]
             return_value=TableflowTopic.from_response(_topic_body(phase="RUNNING"))
@@ -386,9 +374,7 @@ class TestEnableTableflow:
 
     def test_wait_for_running_raises_on_failed(self, mocker) -> None:
         conn = _connect(database_kafka_cluster_id="lkc-1")
-        conn._tableflow_request = Mock(
-            return_value=_ok_response(_topic_body(), status_code=202)
-        )
+        conn._tableflow_request = Mock(return_value=_ok_response(_topic_body(), status_code=202))
         failed = _topic_body(phase="FAILED")
         failed["status"]["error_message"] = "schema boom"
         failed["status"]["failing_table_formats"] = [
@@ -406,9 +392,7 @@ class TestEnableTableflow:
 
     def test_wait_for_running_times_out(self, mocker) -> None:
         conn = _connect(database_kafka_cluster_id="lkc-1")
-        conn._tableflow_request = Mock(
-            return_value=_ok_response(_topic_body(), status_code=202)
-        )
+        conn._tableflow_request = Mock(return_value=_ok_response(_topic_body(), status_code=202))
         # No backoff iterations: the topic never leaves PENDING, so the wait gives up.
         mocker.patch("confluent_sql.connection.sleep_with_backoff", return_value=iter([]))
         with pytest.raises(OperationalError, match="did not reach RUNNING within"):


### PR DESCRIPTION
# Ergonomic statement properties: keys & value enumerations

## Statement property enumerations

- New module `confluent_sql.statement_properties` turns the open-ended `properties=` dict into
  something discoverable and type-checkable, without taking the open-endedness away. Raw `str`
  keys/values still work; the enums are an opt-in, autocomplete-friendly overlay.
- `Property` is a `str` enum of every `sql.*` key from the [Available SET options](https://docs.confluent.io/cloud/current/flink/reference/statements/set.html)
  table (`Property.SNAPSHOT_WRITE_MODE`, `Property.CURRENT_CATALOG`, …). The `client.*` options
  from that same page are gateway/client knobs, not statement properties, and are deliberately
  excluded (noted in the enum docstring so it doesn't read as an oversight).
- `SnapshotWriteMode` (`default`/`fast-write`) and `SnapshotMode` (`now`/`off`) enumerate the two
  fixed value sets we can pin exactly from the docs. Both derive from a shared `PropertyValue`
  base, giving `StatementProperties` (#163) one type to treat uniformly. Free-form values (catalog
  names, time zones, durations) stay plain `str` — no enum where there's no fixed set.
- **StrEnum parity on the 3.10 floor.** Issue #162 sketched `enum.StrEnum`, but the repo supports
  Python ≥3.10 and `StrEnum` is 3.11+. The enums subclass a private `_PropertyEnum` — `(str, Enum)`
  (the house style: `TableFormat`, `ConnectorState`, `TableflowPhase`) with `__str__`/`__format__`
  delegated to `str`, exactly as CPython's `StrEnum` does. Result: members compare, hash,
  JSON-serialize, **and** stringify in logs/error messages as their bare wire string, with no
  `.value` unwrapping at the call site.
- A unit test pins each member's exact wire string, asserts `Property` names precisely the
  documented `sql.*` set (so an accidental add/drop fails loudly), and verifies bare-member JSON
  serialization. A dedicated test pins `str(member)` → wire key; it was written after the
  reserved-key error message was caught leaking `'Property.SNAPSHOT_MODE'` instead of
  `'sql.snapshot.mode'`, which is what drove the `_PropertyEnum` `__str__`/`__format__` fix.

## Connection adoption

- `Connection._RESERVED_STATEMENT_PROPERTIES` and the overlay assignments in `_resolve_properties`
  now reference `Property` members and `SnapshotMode.NOW` instead of bare string literals — one
  source of truth for the driver-owned keys. Verified safe: a user-supplied reserved key still
  gets rejected whether passed as a raw string or a `Property` member, and the error message names
  the wire key either way (parametrized test over both forms).
- `PropertiesDict` widens to `dict[str | Property, str | int | bool | PropertyValue]`. The enum
  arms are redundant to the type checker (both subclass `str`) but document the discoverable
  options and drive autocomplete.

## While here
- Ran `ruff format` which cleaned up some formatting in test files.

## Relationships

- Closes #162
- Child of #161 (Epic: Ergonomic Statement Properties)
