### PR TITLE
typed class StatementProperties.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,11 @@ All notable changes to this dbapi driver will be documented in this file.
   collides with the driver-owned overlay. The enum-typed fields also accept a bare `str` so a
   Flink value newer than this driver can still be passed; a wrong-property enum value, a field of
   the wrong Python type, or an `extra` key that duplicates a modeled field, raises at construction.
-  `extra` is copied into a read-only mapping, so the frozen guarantee holds after construction too. Pass one anywhere a `properties=`
-  dict is accepted (`Cursor.execute`, `execute_snapshot_ddl`, `execute_streaming_ddl`, ...); it is
-  downgraded to a dict and validated identically. Adds the `ScanStartupMode` value enum
-  (`earliest-offset`/`latest-offset`/`timestamp`/`specific-offsets`). (#163)
+  `extra` is copied into a read-only mapping, so the frozen guarantee holds after construction too.
+  Pass one anywhere a `properties=` dict is accepted (`Cursor.execute`, `execute_snapshot_ddl`,
+  `execute_streaming_ddl`, ...); it is downgraded to a dict and validated identically. Adds the
+  `ScanStartupMode` value enum (`earliest-offset`/`latest-offset`/`timestamp`/`specific-offsets`).
+  (#163)
 - New module `confluent_sql.statement_properties` gives statement `SET` options a discoverable,
   type-checkable face alongside the existing open-ended `PropertiesDict`. `Property` is a `str`
   enum of the `sql.*` option keys from the [SET-options reference](https://docs.confluent.io/cloud/current/flink/reference/statements/set.html)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ All notable changes to this dbapi driver will be documented in this file.
   as `"3600 s"`), `scan_startup_mode`, `local_time_zone`, plus an `extra` dict escape hatch for
   options not yet modeled. Only set fields are emitted, so an instance never pins a default nor
   collides with the driver-owned overlay. The enum-typed fields also accept a bare `str` so a
-  Flink value newer than this driver can still be passed; a wrong-property enum value, or an `extra`
-  key that duplicates a modeled field, raises at construction. Pass one anywhere a `properties=`
+  Flink value newer than this driver can still be passed; a wrong-property enum value, a field of
+  the wrong Python type, or an `extra` key that duplicates a modeled field, raises at construction.
+  `extra` is copied into a read-only mapping, so the frozen guarantee holds after construction too. Pass one anywhere a `properties=`
   dict is accepted (`Cursor.execute`, `execute_snapshot_ddl`, `execute_streaming_ddl`, ...); it is
   downgraded to a dict and validated identically. Adds the `ScanStartupMode` value enum
   (`earliest-offset`/`latest-offset`/`timestamp`/`specific-offsets`). (#163)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this dbapi driver will be documented in this file.
 
 ### Added
 
+- `StatementProperties` -- a frozen, keyword-only dataclass giving a typed, autocomplete-friendly
+  way to set the curated statement options instead of hand-building a `sql.*` dict. Fields (all
+  optional): `snapshot_write_mode`, `state_ttl` (a `timedelta`, rendered to a Flink duration such
+  as `"3600 s"`), `scan_startup_mode`, `local_time_zone`, plus an `extra` dict escape hatch for
+  options not yet modeled. Only set fields are emitted, so an instance never pins a default nor
+  collides with the driver-owned overlay. The enum-typed fields also accept a bare `str` so a
+  Flink value newer than this driver can still be passed; a wrong-property enum value, or an `extra`
+  key that duplicates a modeled field, raises at construction. Pass one anywhere a `properties=`
+  dict is accepted (`Cursor.execute`, `execute_snapshot_ddl`, `execute_streaming_ddl`, ...); it is
+  downgraded to a dict and validated identically. Adds the `ScanStartupMode` value enum
+  (`earliest-offset`/`latest-offset`/`timestamp`/`specific-offsets`). (#163)
 - New module `confluent_sql.statement_properties` gives statement `SET` options a discoverable,
   type-checkable face alongside the existing open-ended `PropertiesDict`. `Property` is a `str`
   enum of the `sql.*` option keys from the [SET-options reference](https://docs.confluent.io/cloud/current/flink/reference/statements/set.html)

--- a/src/confluent_sql/__init__.py
+++ b/src/confluent_sql/__init__.py
@@ -60,7 +60,7 @@ from .tableflow import (
     TableflowTopicConfig,
     TableFormat,
 )
-from .types import PropertiesDict, SqlNone, YearMonthInterval
+from .types import PropertiesDict, PropertiesMapping, SqlNone, YearMonthInterval
 
 # DB-API v2 module globals
 apilevel = "2.0"
@@ -114,6 +114,7 @@ __all__ = [
     "threadsafety",
     "paramstyle",
     "PropertiesDict",
+    "PropertiesMapping",
     "Property",
     "PropertyValue",
     "ScanStartupMode",

--- a/src/confluent_sql/__init__.py
+++ b/src/confluent_sql/__init__.py
@@ -39,7 +39,14 @@ from .exceptions import (
 from .execution_mode import ExecutionMode
 from .result_readers import ChangeloggedRow
 from .statement import HIDDEN_LABEL, Op
-from .statement_properties import Property, PropertyValue, SnapshotMode, SnapshotWriteMode
+from .statement_properties import (
+    Property,
+    PropertyValue,
+    ScanStartupMode,
+    SnapshotMode,
+    SnapshotWriteMode,
+    StatementProperties,
+)
 from .tableflow import (
     AzureAdlsStorage,
     ByobAwsStorage,
@@ -109,8 +116,10 @@ __all__ = [
     "PropertiesDict",
     "Property",
     "PropertyValue",
+    "ScanStartupMode",
     "SnapshotMode",
     "SnapshotWriteMode",
+    "StatementProperties",
     "SqlNone",
     "YearMonthInterval",
     "HIDDEN_LABEL",

--- a/src/confluent_sql/connection.py
+++ b/src/confluent_sql/connection.py
@@ -41,7 +41,7 @@ from .retry import (
 )
 from .statement import LABEL_PREFIX as STATEMENT_LABEL_PREFIX
 from .statement import ChangelogRow, Statement
-from .statement_properties import Property, SnapshotMode
+from .statement_properties import Property, SnapshotMode, StatementProperties
 from .tableflow import (
     TableflowPhase,
     TableflowStorage,
@@ -930,7 +930,7 @@ class Connection:
         timeout: int = 3000,
         statement_name: str | None = None,
         statement_labels: list[str] | None = None,
-        properties: PropertiesDict | None = None,
+        properties: PropertiesDict | StatementProperties | None = None,
         *,
         compute_pool_id: str | None = None,
     ) -> Statement:
@@ -956,7 +956,8 @@ class Connection:
                              prefixed with "user.confluent.io/" when stored but you only
                              need to provide the label values (e.g., ["my-ddl-batch", "daily"]).
                              Use HIDDEN_LABEL to mark statements as hidden from default views.
-            properties: Optional dictionary of statement properties to set for this execution.
+            properties: Optional statement properties to set for this execution -- a raw dict or a
+                       `StatementProperties` (downgraded to a dict, then validated identically).
                        Keys must be strings, values must be str, int, or bool.
             compute_pool_id: Optional compute pool ID to use for this statement execution.
                             If not provided, uses the Connection's default compute_pool_id,
@@ -994,7 +995,7 @@ class Connection:
         timeout: int = 3000,
         statement_name: str | None = None,
         statement_labels: list[str] | None = None,
-        properties: PropertiesDict | None = None,
+        properties: PropertiesDict | StatementProperties | None = None,
         *,
         compute_pool_id: str | None = None,
     ) -> Statement:
@@ -1016,7 +1017,8 @@ class Connection:
                              prefixed with "user.confluent.io/" when stored but you only
                              need to provide the label values (e.g., ["streaming-jobs", "daily"]).
                              Use HIDDEN_LABEL to mark statements as hidden from default views.
-            properties: Optional dictionary of statement properties to set for this execution.
+            properties: Optional statement properties to set for this execution -- a raw dict or a
+                       `StatementProperties` (downgraded to a dict, then validated identically).
                        Keys must be strings, values must be str, int, or bool.
             compute_pool_id: Optional compute pool ID to use for this statement execution.
                             If not provided, uses the Connection's default compute_pool_id,
@@ -1454,7 +1456,9 @@ class Connection:
         self._row_type_registry.register_row_type(class_for_flink_row)
 
     def _resolve_properties(
-        self, properties: PropertiesDict | None, execution_mode: ExecutionMode
+        self,
+        properties: PropertiesDict | StatementProperties | None,
+        execution_mode: ExecutionMode,
     ) -> PropertiesDict:
         """
         Validate and merge user properties with system properties.
@@ -1464,8 +1468,10 @@ class Connection:
         and cannot be overridden by user input.
 
         Args:
-            properties: Optional dictionary of user-provided statement properties.
-                       Keys must be strings, values must be str, int, or bool.
+            properties: Optional user-provided statement properties -- either a raw dict (keys
+                       strings, values str/int/bool) or a `StatementProperties`, which is
+                       downgraded to a dict up front and then validated identically (so a
+                       reserved key smuggled through its `extra` is rejected the same way).
             execution_mode: The execution mode (determines if snapshot.mode is set).
 
         Returns:
@@ -1474,6 +1480,9 @@ class Connection:
         Raises:
             InterfaceError: If properties parameter is invalid (not a dict, invalid keys/values).
         """
+        if isinstance(properties, StatementProperties):
+            properties = properties.to_properties_dict()
+
         # Validate properties parameter if provided
         if properties is not None:
             if not isinstance(properties, dict):
@@ -1519,7 +1528,7 @@ class Connection:
         execution_mode: ExecutionMode,
         statement_name: str | None = None,
         statement_labels: list[str] | None = None,
-        properties: PropertiesDict | None = None,
+        properties: PropertiesDict | StatementProperties | None = None,
         *,
         compute_pool_id: str | None = None,
     ) -> dict[str, Any]:
@@ -1535,7 +1544,8 @@ class Connection:
             statement_labels: Optional list of labels for the statement for easier identification
                              in server logs and UIs (defaults to None). Use HIDDEN_LABEL to mark
                              statements as hidden from default views.
-            properties: Optional dictionary of statement properties to set for this execution.
+            properties: Optional statement properties to set for this execution -- a raw dict or a
+                       `StatementProperties` (downgraded to a dict, then validated identically).
                        Keys must be strings, values must be str, int, or bool. System
                        properties (sql.current-catalog, sql.current-database, sql.snapshot.mode)
                        are always set by the driver and cannot be overridden.

--- a/src/confluent_sql/connection.py
+++ b/src/confluent_sql/connection.py
@@ -958,7 +958,9 @@ class Connection:
                              Use HIDDEN_LABEL to mark statements as hidden from default views.
             properties: Optional statement properties to set for this execution -- a raw dict or a
                        `StatementProperties` (downgraded to a dict, then validated identically).
-                       Keys must be strings, values must be str, int, or bool.
+                       In a raw dict, keys must be strings and values str, int, or bool;
+                       `StatementProperties` accepts richer Python types (e.g. a `timedelta`
+                       state_ttl) and renders them to wire values before that validation.
             compute_pool_id: Optional compute pool ID to use for this statement execution.
                             If not provided, uses the Connection's default compute_pool_id,
                             if any; otherwise Confluent Cloud Flink runs the statement in the
@@ -1019,7 +1021,9 @@ class Connection:
                              Use HIDDEN_LABEL to mark statements as hidden from default views.
             properties: Optional statement properties to set for this execution -- a raw dict or a
                        `StatementProperties` (downgraded to a dict, then validated identically).
-                       Keys must be strings, values must be str, int, or bool.
+                       In a raw dict, keys must be strings and values str, int, or bool;
+                       `StatementProperties` accepts richer Python types (e.g. a `timedelta`
+                       state_ttl) and renders them to wire values before that validation.
             compute_pool_id: Optional compute pool ID to use for this statement execution.
                             If not provided, uses the Connection's default compute_pool_id,
                             if any; otherwise Confluent Cloud Flink runs the statement in the

--- a/src/confluent_sql/cursor.py
+++ b/src/confluent_sql/cursor.py
@@ -31,6 +31,7 @@ from .result_readers import (
     ResultTupleOrDict,
 )
 from .statement import Statement
+from .statement_properties import StatementProperties
 from .types import PropertiesDict, convert_statement_parameters
 
 if TYPE_CHECKING:
@@ -182,7 +183,7 @@ class Cursor:
         timeout: int = 3000,
         statement_name: str | None = None,
         statement_labels: list[str] | None = None,
-        properties: PropertiesDict | None = None,
+        properties: PropertiesDict | StatementProperties | None = None,
         compute_pool_id: str | None = None,
     ) -> None:
         """
@@ -202,7 +203,8 @@ class Cursor:
                              Use Connection.list_statements(label=...) to retrieve statements
                              by label. The special HIDDEN_LABEL constant can be used to mark
                              statements as hidden from default views in UIs and monitoring tools.
-            properties: Optional dictionary of statement properties to set for this execution.
+            properties: Optional statement properties to set for this execution -- a raw dict or a
+                       `StatementProperties` (downgraded to a dict, then validated identically).
                        Keys must be strings, values must be str, int, or bool. System
                        properties (sql.current-catalog, sql.current-database, sql.snapshot.mode)
                        are always set by the driver and cannot be overridden.
@@ -803,7 +805,7 @@ class Cursor:
         parameters: tuple | list | None = None,
         statement_name: str | None = None,
         statement_labels: list[str] | None = None,
-        properties: PropertiesDict | None = None,
+        properties: PropertiesDict | StatementProperties | None = None,
         *,
         compute_pool_id: str | None = None,
     ) -> Statement:
@@ -817,7 +819,7 @@ class Cursor:
                             not provided)
             statement_labels: Optional list of labels for the statement for easier identification
                              in server logs and UIs (defaults to None)
-            properties: Optional dictionary of statement properties (optional)
+            properties: Optional statement properties -- a raw dict or a `StatementProperties`
             compute_pool_id: Optional compute pool ID to use for this statement execution.
                             If not provided, uses the Connection's default compute_pool_id,
                             if any; otherwise Confluent Cloud Flink runs the statement in the

--- a/src/confluent_sql/cursor.py
+++ b/src/confluent_sql/cursor.py
@@ -205,7 +205,9 @@ class Cursor:
                              statements as hidden from default views in UIs and monitoring tools.
             properties: Optional statement properties to set for this execution -- a raw dict or a
                        `StatementProperties` (downgraded to a dict, then validated identically).
-                       Keys must be strings, values must be str, int, or bool. System
+                       In a raw dict, keys must be strings and values str, int, or bool;
+                       `StatementProperties` accepts richer Python types (e.g. a `timedelta`
+                       state_ttl) and renders them to wire values before that validation. System
                        properties (sql.current-catalog, sql.current-database, sql.snapshot.mode)
                        are always set by the driver and cannot be overridden.
             compute_pool_id: Optional compute pool ID to use for this statement execution.

--- a/src/confluent_sql/statement_properties.py
+++ b/src/confluent_sql/statement_properties.py
@@ -171,7 +171,8 @@ class StatementProperties:
     extra: PropertiesDict = field(default_factory=dict)
     """Escape hatch for SET options not modeled as a typed field above -- raw wire keys to values.
     May not carry a key a typed field already models; doing so raises at construction. The dict is
-    copied into a read-only mapping at construction, so the instance stays as frozen as the fields."""
+    copied into a read-only mapping at construction, so the instance stays as frozen as its
+    fields."""
 
     _MODELED_KEY_TO_FIELD: ClassVar[dict[Property, str]] = {
         Property.SNAPSHOT_WRITE_MODE: "snapshot_write_mode",
@@ -188,7 +189,7 @@ class StatementProperties:
         self._reject_wrong_field_types()
         self._reject_extra_collisions()
         # Snapshot extra into a read-only mapping so the collision check above can't be voided by
-        # mutating extra after construction. object.__setattr__ is the frozen-dataclass escape hatch.
+        # mutating extra after construction. object.__setattr__ is the frozen escape hatch.
         object.__setattr__(self, "extra", MappingProxyType(dict(self.extra)))
 
     @staticmethod

--- a/src/confluent_sql/statement_properties.py
+++ b/src/confluent_sql/statement_properties.py
@@ -17,6 +17,7 @@ stringify to it in logs and error messages too -- all with no `.value` unwrappin
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import timedelta
 from enum import Enum
@@ -28,7 +29,7 @@ from .exceptions import InterfaceError
 if TYPE_CHECKING:
     # Imported for annotations only: types.py imports the enums below, so a runtime import here
     # would close a cycle. `from __future__ import annotations` keeps the references lazy.
-    from .types import PropertiesDict
+    from .types import PropertiesDict, PropertiesMapping
 
 
 class _PropertyEnum(str, Enum):
@@ -168,11 +169,11 @@ class StatementProperties:
     `TIMESTAMP_LTZ` to types without a zone (`TIMESTAMP`, `TIME`, or `STRING`). A TZDB id like
     `"America/Los_Angeles"` or a fixed offset like `"GMT+03:00"`."""
 
-    extra: PropertiesDict = field(default_factory=dict)
+    extra: PropertiesMapping = field(default_factory=dict)
     """Escape hatch for SET options not modeled as a typed field above -- raw wire keys to values.
-    May not carry a key a typed field already models; doing so raises at construction. The dict is
-    copied into a read-only mapping at construction, so the instance stays as frozen as its
-    fields."""
+    May not carry a key a typed field already models; doing so raises at construction. Accepts any
+    mapping at construction and is copied into a read-only one, so the instance stays as frozen as
+    its fields -- hence the read-only `PropertiesMapping` annotation (not `PropertiesDict`)."""
 
     _MODELED_KEY_TO_FIELD: ClassVar[dict[Property, str]] = {
         Property.SNAPSHOT_WRITE_MODE: "snapshot_write_mode",
@@ -220,8 +221,8 @@ class StatementProperties:
         )
         self._reject_wrong_type("state_ttl", self.state_ttl, timedelta, "a timedelta or None")
         self._reject_wrong_type("local_time_zone", self.local_time_zone, str, "a str or None")
-        if not isinstance(self.extra, dict):
-            raise InterfaceError(f"extra must be a dict, got {type(self.extra).__name__}")
+        if not isinstance(self.extra, Mapping):
+            raise InterfaceError(f"extra must be a mapping, got {type(self.extra).__name__}")
 
     @staticmethod
     def _reject_wrong_type(

--- a/src/confluent_sql/statement_properties.py
+++ b/src/confluent_sql/statement_properties.py
@@ -194,8 +194,13 @@ class StatementProperties:
 
     @staticmethod
     def _reject_wrong_enum(field_name: str, value: object, expected: type[PropertyValue]) -> None:
-        """Reject a `PropertyValue` belonging to a different property; a raw str always passes."""
-        if isinstance(value, PropertyValue) and not isinstance(value, expected):
+        """Reject any Enum that isn't the field's own value enum; a raw str always passes.
+
+        Checks `Enum`, not just `PropertyValue`: every `_PropertyEnum` member (including a
+        `Property` *key*) is also a `str`, so narrowing to `PropertyValue` would let a stray
+        `Property` slip past both this and the str type check and serialize as a bogus wire value.
+        """
+        if isinstance(value, Enum) and not isinstance(value, expected):
             raise InterfaceError(
                 f"{field_name} was given a {type(value).__name__}; "
                 f"expected a {expected.__name__} or a raw str"

--- a/src/confluent_sql/statement_properties.py
+++ b/src/confluent_sql/statement_properties.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import timedelta
 from enum import Enum
+from types import MappingProxyType
 from typing import TYPE_CHECKING, ClassVar
 
 from .exceptions import InterfaceError
@@ -100,7 +101,8 @@ class ScanStartupMode(PropertyValue):
     This is Confluent's set, which is deliberately *not* Apache Flink's: Flink additionally offers
     `group-offsets` and defaults to it, whereas Confluent omits it and defaults to
     `earliest-offset`. `timestamp` and `specific-offsets` each require their companion option
-    (`scan.startup.timestamp-millis` / `scan.startup.specific-offsets`) to be set as well.
+    (`sql.tables.scan.startup.timestamp-millis` / `sql.tables.scan.startup.specific-offsets`) to be
+    set as well.
     """
 
     EARLIEST_OFFSET = "earliest-offset"
@@ -168,7 +170,8 @@ class StatementProperties:
 
     extra: PropertiesDict = field(default_factory=dict)
     """Escape hatch for SET options not modeled as a typed field above -- raw wire keys to values.
-    May not carry a key a typed field already models; doing so raises at construction."""
+    May not carry a key a typed field already models; doing so raises at construction. The dict is
+    copied into a read-only mapping at construction, so the instance stays as frozen as the fields."""
 
     _MODELED_KEY_TO_FIELD: ClassVar[dict[Property, str]] = {
         Property.SNAPSHOT_WRITE_MODE: "snapshot_write_mode",
@@ -182,7 +185,11 @@ class StatementProperties:
     def __post_init__(self) -> None:
         self._reject_wrong_enum("snapshot_write_mode", self.snapshot_write_mode, SnapshotWriteMode)
         self._reject_wrong_enum("scan_startup_mode", self.scan_startup_mode, ScanStartupMode)
+        self._reject_wrong_field_types()
         self._reject_extra_collisions()
+        # Snapshot extra into a read-only mapping so the collision check above can't be voided by
+        # mutating extra after construction. object.__setattr__ is the frozen-dataclass escape hatch.
+        object.__setattr__(self, "extra", MappingProxyType(dict(self.extra)))
 
     @staticmethod
     def _reject_wrong_enum(field_name: str, value: object, expected: type[PropertyValue]) -> None:
@@ -191,6 +198,33 @@ class StatementProperties:
             raise InterfaceError(
                 f"{field_name} was given a {type(value).__name__}; "
                 f"expected a {expected.__name__} or a raw str"
+            )
+
+    def _reject_wrong_field_types(self) -> None:
+        """Reject a field given the wrong Python type, so a bad value surfaces as a consistent
+        InterfaceError here rather than a TypeError deep in rendering (e.g. a str `state_ttl`
+        reaching `_to_flink_duration`). Enum-typed fields accept their bare `str` too."""
+        self._reject_wrong_type(
+            "snapshot_write_mode", self.snapshot_write_mode, str,
+            "a SnapshotWriteMode, a raw str, or None",
+        )
+        self._reject_wrong_type(
+            "scan_startup_mode", self.scan_startup_mode, str,
+            "a ScanStartupMode, a raw str, or None",
+        )
+        self._reject_wrong_type("state_ttl", self.state_ttl, timedelta, "a timedelta or None")
+        self._reject_wrong_type("local_time_zone", self.local_time_zone, str, "a str or None")
+        if not isinstance(self.extra, dict):
+            raise InterfaceError(f"extra must be a dict, got {type(self.extra).__name__}")
+
+    @staticmethod
+    def _reject_wrong_type(
+        field_name: str, value: object, expected: type, description: str
+    ) -> None:
+        """Reject a non-None field value that isn't an instance of `expected`; None is always ok."""
+        if value is not None and not isinstance(value, expected):
+            raise InterfaceError(
+                f"{field_name} must be {description}, got {type(value).__name__}"
             )
 
     def _reject_extra_collisions(self) -> None:

--- a/src/confluent_sql/statement_properties.py
+++ b/src/confluent_sql/statement_properties.py
@@ -15,7 +15,19 @@ straight into `PropertiesDict`, satisfy the `isinstance(v, (str, int, bool))` va
 stringify to it in logs and error messages too -- all with no `.value` unwrapping at the call site.
 """
 
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import timedelta
 from enum import Enum
+from typing import TYPE_CHECKING, ClassVar
+
+from .exceptions import InterfaceError
+
+if TYPE_CHECKING:
+    # Imported for annotations only: types.py imports the enums below, so a runtime import here
+    # would close a cycle. `from __future__ import annotations` keeps the references lazy.
+    from .types import PropertiesDict
 
 
 class _PropertyEnum(str, Enum):
@@ -80,3 +92,129 @@ class SnapshotMode(PropertyValue):
 
     NOW = "now"
     OFF = "off"
+
+
+class ScanStartupMode(PropertyValue):
+    """Values for `Property.SCAN_STARTUP_MODE` -- where Confluent-native table scans begin.
+
+    This is Confluent's set, which is deliberately *not* Apache Flink's: Flink additionally offers
+    `group-offsets` and defaults to it, whereas Confluent omits it and defaults to
+    `earliest-offset`. `timestamp` and `specific-offsets` each require their companion option
+    (`scan.startup.timestamp-millis` / `scan.startup.specific-offsets`) to be set as well.
+    """
+
+    EARLIEST_OFFSET = "earliest-offset"
+    LATEST_OFFSET = "latest-offset"
+    TIMESTAMP = "timestamp"
+    SPECIFIC_OFFSETS = "specific-offsets"
+
+
+def _to_flink_duration(delta: timedelta) -> str:
+    """Render a `timedelta` to a Flink `Duration` string, e.g. `timedelta(hours=1)` -> `"3600 s"`.
+
+    Whole seconds print as `"<n> s"`, otherwise `"<n> ms"`. Flink Durations bottom out at
+    millisecond granularity, so a sub-millisecond `timedelta` would silently lose precision -- that
+    raises instead, as does a negative duration (meaningless for the TTL this serves).
+    """
+    total_us = delta // timedelta(microseconds=1)
+    if total_us < 0:
+        raise ValueError(f"duration must be non-negative, got negative {delta!r}")
+    if total_us % 1000 != 0:
+        raise ValueError(f"duration has sub-millisecond precision Flink cannot express: {delta!r}")
+    total_ms = total_us // 1000
+    if total_ms % 1000 == 0:
+        return f"{total_ms // 1000} s"
+    return f"{total_ms} ms"
+
+
+@dataclass(frozen=True, kw_only=True)
+class StatementProperties:
+    """Typed, validated view over a curated subset of Flink SET options.
+
+    Unset fields (None) are omitted entirely; only explicitly set options are emitted, so this
+    never fights the driver-owned overlay (catalog/database/snapshot.mode) or pins a server default.
+    An `extra` dict is the escape hatch for options this class does not yet model -- and *only* for
+    those: putting a modeled option's key in `extra` raises, so each property has exactly one
+    spelling.
+
+    The enum-typed fields also accept a raw `str` for forward compatibility: a Flink-side value this
+    driver doesn't model yet can be passed directly on the field rather than smuggled through
+    `extra`. A `PropertyValue` from the *wrong* property (e.g. a `SnapshotMode` on
+    `snapshot_write_mode`) is a category error and is rejected at construction.
+
+    Field definitions and defaults track the Flink "Available SET options" reference:
+    https://docs.confluent.io/cloud/current/flink/reference/statements/set.html#available-set-options
+    """
+
+    snapshot_write_mode: SnapshotWriteMode | str | None = None
+    """`sql.snapshot.write-mode` (server default `"default"`): write mode for snapshot queries.
+    `"fast-write"` trades exactly-once delivery for speed. Valid only in snapshot mode."""
+
+    state_ttl: timedelta | None = None
+    """`sql.state-ttl` (server default 0 ms, meaning no expiry): the minimum time idle state --
+    state that hasn't been updated -- is retained before it becomes eligible for clearance (the
+    system decides the actual clearance moment after this interval). Rendered to a Flink duration
+    string."""
+
+    scan_startup_mode: ScanStartupMode | str | None = None
+    """`sql.tables.scan.startup.mode` (server default: the table's own): overwrites
+    `scan.startup.mode` for Confluent-native tables in newly created queries. Not applied to a table
+    that already uses a non-default value."""
+
+    local_time_zone: str | None = None
+    """`sql.local-time-zone` (server default `"UTC"`): the time zone used when converting
+    `TIMESTAMP_LTZ` to types without a zone (`TIMESTAMP`, `TIME`, or `STRING`). A TZDB id like
+    `"America/Los_Angeles"` or a fixed offset like `"GMT+03:00"`."""
+
+    extra: PropertiesDict = field(default_factory=dict)
+    """Escape hatch for SET options not modeled as a typed field above -- raw wire keys to values.
+    May not carry a key a typed field already models; doing so raises at construction."""
+
+    _MODELED_KEY_TO_FIELD: ClassVar[dict[Property, str]] = {
+        Property.SNAPSHOT_WRITE_MODE: "snapshot_write_mode",
+        Property.STATE_TTL: "state_ttl",
+        Property.SCAN_STARTUP_MODE: "scan_startup_mode",
+        Property.LOCAL_TIME_ZONE: "local_time_zone",
+    }
+    """Every property this class models as a typed field, mapped to that field's name -- the source
+    of truth for both rejecting `extra` collisions and naming the field to use instead."""
+
+    def __post_init__(self) -> None:
+        self._reject_wrong_enum("snapshot_write_mode", self.snapshot_write_mode, SnapshotWriteMode)
+        self._reject_wrong_enum("scan_startup_mode", self.scan_startup_mode, ScanStartupMode)
+        self._reject_extra_collisions()
+
+    @staticmethod
+    def _reject_wrong_enum(field_name: str, value: object, expected: type[PropertyValue]) -> None:
+        """Reject a `PropertyValue` belonging to a different property; a raw str always passes."""
+        if isinstance(value, PropertyValue) and not isinstance(value, expected):
+            raise InterfaceError(
+                f"{field_name} was given a {type(value).__name__}; "
+                f"expected a {expected.__name__} or a raw str"
+            )
+
+    def _reject_extra_collisions(self) -> None:
+        """Reject any `extra` key a typed field already models -- one spelling per property."""
+        for key in self.extra:
+            field_name = self._MODELED_KEY_TO_FIELD.get(key)  # type: ignore[arg-type]
+            if field_name is not None:
+                raise InterfaceError(
+                    f"extra may not contain '{key}'; set it via the {field_name} field instead"
+                )
+
+    def to_properties_dict(self) -> PropertiesDict:
+        """Render to the wire properties dict: `extra` first, then each set typed field on top.
+
+        Typed values are assigned directly, not via `.value`, so an enum member and a raw
+        forward-compat string both serialize correctly (`_PropertyEnum` members are wire strings).
+        """
+        props: PropertiesDict = dict(self.extra)
+        if self.snapshot_write_mode is not None:
+            props[Property.SNAPSHOT_WRITE_MODE] = self.snapshot_write_mode
+        if self.state_ttl is not None:
+            props[Property.STATE_TTL] = _to_flink_duration(self.state_ttl)
+        if self.scan_startup_mode is not None:
+            props[Property.SCAN_STARTUP_MODE] = self.scan_startup_mode
+        if self.local_time_zone is not None:
+            props[Property.LOCAL_TIME_ZONE] = self.local_time_zone
+        return props

--- a/src/confluent_sql/types.py
+++ b/src/confluent_sql/types.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import re
 from collections import Counter
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, fields, is_dataclass
 from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
 __all__ = [
     "ColumnTypeDefinition",
     "PropertiesDict",
+    "PropertiesMapping",
     "StrAnyDict",
     "StatementTypeConverter",
     "TypeConverter",
@@ -67,6 +68,11 @@ PropertiesDict: TypeAlias = dict[str | Property, str | int | bool | PropertyValu
 `Property` member; values are str/int/bool or a `PropertyValue` member. The enum arms are
 redundant to the type checker (both subclass str) but document the discoverable options and
 enable autocomplete."""
+
+PropertiesMapping: TypeAlias = Mapping[str | Property, str | int | bool | PropertyValue]
+"""Read-only counterpart to `PropertiesDict` -- same keys and values, but immutable. For a field
+that hands back a snapshot the caller must not mutate (e.g. `StatementProperties.extra`), so type
+checkers reject item assignment rather than allowing a mutation that fails at runtime."""
 
 
 @dataclass

--- a/tests/integration/test_cursor.py
+++ b/tests/integration/test_cursor.py
@@ -1,5 +1,6 @@
 import re
 import time
+from datetime import datetime, timedelta
 from uuid import uuid4
 
 import pytest
@@ -9,8 +10,8 @@ from confluent_sql import (
     Connection,
     Cursor,
     InterfaceError,
-    PropertiesDict,
     StatementDeletedError,
+    StatementProperties,
 )
 from confluent_sql.exceptions import NotSupportedError
 from confluent_sql.statement import Op, Phase, Statement
@@ -161,17 +162,20 @@ class TestCursor:
     def test_cursor_execute_with_statement_properties(
         self, populated_table_connection: Connection, test_table_name: str
     ):
-        """Test that statement properties are accepted and persisted in the Statement.
+        """Test that a StatementProperties is accepted and persisted in the Statement.
 
         Verifies that:
-        1. cursor.execute() accepts a properties parameter
-        2. The statement executes successfully with custom properties
-        3. The returned Statement object contains the provided properties
+        1. cursor.execute() accepts a StatementProperties for its properties parameter
+        2. The statement executes successfully with those properties
+        3. The returned Statement object contains the provided properties, with the timedelta
+           rendered to the Flink duration string the server echoes back ("100 ms")
         4. Results can be fetched from the statement
         """
         cursor = populated_table_connection.cursor()
-        properties: PropertiesDict = {"sql.state-ttl": "100 ms"}
-        cursor.execute(f"SELECT * FROM {test_table_name}", properties=properties)
+        cursor.execute(
+            f"SELECT * FROM {test_table_name}",
+            properties=StatementProperties(state_ttl=timedelta(milliseconds=100)),
+        )
 
         # Verify statement was created and completed
         statement = cursor._statement
@@ -185,6 +189,34 @@ class TestCursor:
         # Verify we can fetch results
         row = cursor.fetchone()
         assert row is not None  # Test table is populated
+
+    def test_local_time_zone_shifts_naive_timestamp(self, connection: Connection):
+        """StatementProperties.local_time_zone changes how a naive TIMESTAMP is rendered.
+
+        LOCALTIMESTAMP yields a plain TIMESTAMP (tz-naive) in the session's local time zone, so
+        reading it under US Eastern vs US Central -- zones that always sit exactly one hour apart,
+        DST transitions and all -- gives wall-clock values ~1h apart. The two queries run a few
+        seconds apart, hence the +/- 1 minute slack.
+        """
+
+        def local_wall_clock(time_zone: str) -> datetime:
+            cursor = connection.cursor()
+            cursor.execute(
+                "SELECT LOCALTIMESTAMP",
+                properties=StatementProperties(local_time_zone=time_zone),
+            )
+            row = cursor.fetchone()
+            assert row is not None
+            value = row[0]  # type: ignore[index]
+            # A plain TIMESTAMP, not TIMESTAMP_LTZ: naive, so the local time zone actually moves it.
+            assert isinstance(value, datetime)
+            assert value.tzinfo is None
+            return value
+
+        eastern = local_wall_clock("America/New_York")
+        central = local_wall_clock("America/Chicago")
+
+        assert abs((eastern - central) - timedelta(hours=1)) <= timedelta(minutes=1)
 
     def test_cursor_description_raises_if_closed(self, cursor: Cursor):
         cursor.close()

--- a/tests/integration/test_cursor.py
+++ b/tests/integration/test_cursor.py
@@ -198,8 +198,8 @@ class TestCursor:
         DST transitions and all -- gives wall-clock values ~1h apart.
 
         The two queries run sequentially, so `eastern` is sampled before `central`: their naive
-        difference is `1h - dt`, where `dt` is the real time that elapsed between the two server-side
-        evaluations. We bracket both queries with a client-side clock and bound the acceptable skew
+        difference is `1h - dt`, where `dt` is the real time that elapsed between the two
+        server-side evaluations. We bracket both queries with a client-side clock and bound the skew
         by that measured elapsed (plus a small cushion for sub-second rounding), so a slow backend
         can stretch `dt` without failing a correct result.
         """

--- a/tests/integration/test_cursor.py
+++ b/tests/integration/test_cursor.py
@@ -195,8 +195,13 @@ class TestCursor:
 
         LOCALTIMESTAMP yields a plain TIMESTAMP (tz-naive) in the session's local time zone, so
         reading it under US Eastern vs US Central -- zones that always sit exactly one hour apart,
-        DST transitions and all -- gives wall-clock values ~1h apart. The two queries run a few
-        seconds apart, hence the +/- 1 minute slack.
+        DST transitions and all -- gives wall-clock values ~1h apart.
+
+        The two queries run sequentially, so `eastern` is sampled before `central`: their naive
+        difference is `1h - dt`, where `dt` is the real time that elapsed between the two server-side
+        evaluations. We bracket both queries with a client-side clock and bound the acceptable skew
+        by that measured elapsed (plus a small cushion for sub-second rounding), so a slow backend
+        can stretch `dt` without failing a correct result.
         """
 
         def local_wall_clock(time_zone: str) -> datetime:
@@ -213,10 +218,13 @@ class TestCursor:
             assert value.tzinfo is None
             return value
 
+        started = time.monotonic()
         eastern = local_wall_clock("America/New_York")
         central = local_wall_clock("America/Chicago")
+        elapsed = timedelta(seconds=time.monotonic() - started)
 
-        assert abs((eastern - central) - timedelta(hours=1)) <= timedelta(minutes=1)
+        skew = abs((eastern - central) - timedelta(hours=1))
+        assert skew <= elapsed + timedelta(seconds=1)
 
     def test_cursor_description_raises_if_closed(self, cursor: Cursor):
         cursor.close()

--- a/tests/unit/test_connection_unit_properties.py
+++ b/tests/unit/test_connection_unit_properties.py
@@ -8,7 +8,12 @@ import pytest
 from confluent_sql import InterfaceError, connect
 from confluent_sql.connection import Connection
 from confluent_sql.execution_mode import ExecutionMode
-from confluent_sql.statement_properties import Property, SnapshotWriteMode
+from confluent_sql.statement_properties import (
+    Property,
+    ScanStartupMode,
+    SnapshotWriteMode,
+    StatementProperties,
+)
 
 
 @pytest.fixture()
@@ -186,6 +191,44 @@ class TestExecuteStatementProperties:
         # ...and it round-trips through JSON as a bare string, not an enum repr.
         serialized = json.loads(json.dumps(payload))
         assert serialized["spec"]["properties"]["sql.snapshot.write-mode"] == "fast-write"
+
+    def test_statement_properties_object_downgrades_and_reaches_wire(
+        self, invalid_credential_connection, mocker
+    ):
+        """A StatementProperties passed as `properties` is downgraded via to_properties_dict and its
+        options reach the wire alongside the driver's system overlay."""
+        request_mock = self.install_request_mock(invalid_credential_connection, mocker)
+
+        invalid_credential_connection._execute_statement(
+            "SELECT 1",
+            ExecutionMode.SNAPSHOT,
+            properties=StatementProperties(
+                snapshot_write_mode=SnapshotWriteMode.FAST_WRITE,
+                scan_startup_mode=ScanStartupMode.LATEST_OFFSET,
+            ),
+        )
+
+        props = request_mock.call_args[1]["json"]["spec"]["properties"]
+        assert props["sql.snapshot.write-mode"] == "fast-write"
+        assert props["sql.tables.scan.startup.mode"] == "latest-offset"
+        # System overlay still applied on top of the downgraded dict.
+        assert "sql.current-catalog" in props
+        assert props["sql.snapshot.mode"] == "now"
+
+    def test_statement_properties_extra_reserved_key_still_rejected(
+        self, invalid_credential_connection
+    ):
+        """A reserved/driver-owned key smuggled through StatementProperties.extra is rejected by
+        the same wire-validation a raw dict faces -- the downgrade doesn't launder it past the
+        reserved-property check."""
+        with pytest.raises(
+            InterfaceError, match="'sql.snapshot.mode' is a reserved system property"
+        ):
+            invalid_credential_connection._execute_statement(
+                "SELECT 1",
+                ExecutionMode.SNAPSHOT,
+                properties=StatementProperties(extra={"sql.snapshot.mode": "off"}),
+            )
 
     def test_properties_streaming_mode_no_snapshot(self, invalid_credential_connection, mocker):
         """Verify snapshot.mode is not set in streaming mode."""

--- a/tests/unit/test_statement_properties_unit.py
+++ b/tests/unit/test_statement_properties_unit.py
@@ -214,10 +214,20 @@ class TestStatementProperties:
                 "SnapshotWriteMode",
                 "ScanStartupMode",
             ),
+            # A Property key member is also a str, so it must be rejected as an Enum -- not waved
+            # through by the str-based type check and serialized as a bogus wire value.
+            (
+                {"snapshot_write_mode": Property.SNAPSHOT_WRITE_MODE},
+                "Property",
+                "SnapshotWriteMode",
+            ),
+            ({"scan_startup_mode": Property.SCAN_STARTUP_MODE}, "Property", "ScanStartupMode"),
         ],
     )
     def test_wrong_enum_member_raises(self, kwargs, wrong_type, expected_type):
-        """A PropertyValue from the wrong property is a category error, rejected at construction."""
+        """Any Enum that isn't the field's own value enum is a category error, rejected at
+        construction -- including a str-based Enum like Property that would otherwise pass the
+        str type check and serialize as a bogus wire value. A raw str still passes."""
         field_name = next(iter(kwargs))
         with pytest.raises(
             InterfaceError,

--- a/tests/unit/test_statement_properties_unit.py
+++ b/tests/unit/test_statement_properties_unit.py
@@ -292,8 +292,8 @@ class TestStatementProperties:
         ):
             StatementProperties(**kwargs)
 
-    def test_non_dict_extra_raises_at_construction(self):
-        with pytest.raises(InterfaceError, match=r"extra must be a dict, got list"):
+    def test_non_mapping_extra_raises_at_construction(self):
+        with pytest.raises(InterfaceError, match=r"extra must be a mapping, got list"):
             StatementProperties(extra=[("sql.dry-run", True)])  # type: ignore[arg-type]
 
     def test_extra_is_read_only_after_construction(self):

--- a/tests/unit/test_statement_properties_unit.py
+++ b/tests/unit/test_statement_properties_unit.py
@@ -1,6 +1,7 @@
 """Unit tests for the statement_properties enumerations (Issue #162)."""
 
 import json
+import re
 from datetime import timedelta
 
 import pytest
@@ -252,6 +253,53 @@ class TestStatementProperties:
         """A Property member used as an extra key collides just like its raw string would."""
         with pytest.raises(InterfaceError, match=r"extra may not contain 'sql\.state-ttl'"):
             StatementProperties(extra={Property.STATE_TTL: "3600 s"})
+
+    @pytest.mark.parametrize(
+        ("kwargs", "field_name", "description"),
+        [
+            ({"state_ttl": "100 ms"}, "state_ttl", "a timedelta or None"),
+            ({"local_time_zone": 5}, "local_time_zone", "a str or None"),
+            (
+                {"snapshot_write_mode": 5},
+                "snapshot_write_mode",
+                "a SnapshotWriteMode, a raw str, or None",
+            ),
+            (
+                {"scan_startup_mode": 5},
+                "scan_startup_mode",
+                "a ScanStartupMode, a raw str, or None",
+            ),
+        ],
+    )
+    def test_wrong_field_type_raises_at_construction(self, kwargs, field_name, description):
+        """A field given the wrong Python type is rejected at construction with a consistent
+        InterfaceError -- not left to blow up as a TypeError deep in rendering (e.g. a str
+        state_ttl reaching _to_flink_duration)."""
+        got = type(next(iter(kwargs.values()))).__name__
+        with pytest.raises(
+            InterfaceError,
+            match=rf"{field_name} must be {re.escape(description)}, got {got}",
+        ):
+            StatementProperties(**kwargs)
+
+    def test_non_dict_extra_raises_at_construction(self):
+        with pytest.raises(InterfaceError, match=r"extra must be a dict, got list"):
+            StatementProperties(extra=[("sql.dry-run", True)])  # type: ignore[arg-type]
+
+    def test_extra_is_read_only_after_construction(self):
+        """extra is snapshotted into a read-only mapping, so the one-spelling-per-property
+        invariant enforced at construction can't be broken by mutating extra afterward."""
+        sp = StatementProperties(extra={"sql.some.future-option": "x"})
+        with pytest.raises(TypeError):
+            sp.extra["sql.state-ttl"] = "3600 s"  # type: ignore[index]
+
+    def test_source_extra_dict_is_copied_not_aliased(self):
+        """extra is copied at construction, so later mutation of the caller's own dict does not
+        leak into the (advertised-frozen) instance."""
+        source: dict = {"sql.some.future-option": "x"}
+        sp = StatementProperties(extra=source)
+        source["sql.another-future-option"] = "y"
+        assert sp.to_properties_dict() == {"sql.some.future-option": "x"}
 
 
 @pytest.mark.unit

--- a/tests/unit/test_statement_properties_unit.py
+++ b/tests/unit/test_statement_properties_unit.py
@@ -1,15 +1,20 @@
 """Unit tests for the statement_properties enumerations (Issue #162)."""
 
 import json
+from datetime import timedelta
 
 import pytest
 
 import confluent_sql
+from confluent_sql import InterfaceError
 from confluent_sql.statement_properties import (
     Property,
     PropertyValue,
+    ScanStartupMode,
     SnapshotMode,
     SnapshotWriteMode,
+    StatementProperties,
+    _to_flink_duration,
 )
 
 # Every sql.* statement key from the "Available SET options" table, verbatim off the wire.
@@ -102,9 +107,159 @@ class TestPropertyValues:
 
 
 @pytest.mark.unit
+class TestScanStartupMode:
+    """The scan.startup.mode value enum -- Confluent's set, which is not Apache Flink's."""
+
+    @pytest.mark.parametrize(
+        ("member", "wire_value"),
+        [
+            (ScanStartupMode.EARLIEST_OFFSET, "earliest-offset"),
+            (ScanStartupMode.LATEST_OFFSET, "latest-offset"),
+            (ScanStartupMode.TIMESTAMP, "timestamp"),
+            (ScanStartupMode.SPECIFIC_OFFSETS, "specific-offsets"),
+        ],
+    )
+    def test_member_pins_exact_wire_value(self, member, wire_value):
+        """Each member's value and str-equality both equal the wire value exactly."""
+        assert member.value == wire_value
+        assert member == wire_value
+
+    def test_derives_from_property_value(self):
+        assert issubclass(ScanStartupMode, PropertyValue)
+
+    def test_omits_apache_flink_group_offsets(self):
+        """Confluent's scan.startup.mode has no group-offsets (Apache Flink's default); guard
+        against it creeping in from an Apache-Flink-shaped mental model."""
+        assert "group-offsets" not in {member.value for member in ScanStartupMode}
+
+
+@pytest.mark.unit
+class TestToFlinkDuration:
+    """timedelta -> Flink Duration string: whole seconds as `s`, else `ms`, else raise."""
+
+    @pytest.mark.parametrize(
+        ("delta", "wire"),
+        [
+            (timedelta(hours=1), "3600 s"),
+            (timedelta(minutes=5), "300 s"),
+            (timedelta(seconds=90), "90 s"),
+            (timedelta(0), "0 s"),
+            (timedelta(milliseconds=1500), "1500 ms"),
+            (timedelta(milliseconds=250), "250 ms"),
+        ],
+    )
+    def test_renders_expected_duration(self, delta, wire):
+        assert _to_flink_duration(delta) == wire
+
+    @pytest.mark.parametrize("delta", [timedelta(microseconds=1), timedelta(microseconds=500)])
+    def test_sub_millisecond_raises(self, delta):
+        """Flink Durations bottom out at ms; sub-ms precision would be silently lost, so raise."""
+        with pytest.raises(ValueError, match="sub-millisecond"):
+            _to_flink_duration(delta)
+
+    def test_negative_raises(self):
+        with pytest.raises(ValueError, match="negative"):
+            _to_flink_duration(timedelta(seconds=-1))
+
+
+@pytest.mark.unit
+class TestStatementProperties:
+    """The frozen typed view: rendering, forward-compat strings, and construction-time coherence."""
+
+    def test_empty_renders_empty_dict(self):
+        """An all-unset instance emits nothing -- never pins a default or fights the overlay."""
+        assert StatementProperties().to_properties_dict() == {}
+
+    def test_all_typed_fields_render_to_wire(self):
+        sp = StatementProperties(
+            snapshot_write_mode=SnapshotWriteMode.FAST_WRITE,
+            state_ttl=timedelta(hours=1),
+            scan_startup_mode=ScanStartupMode.LATEST_OFFSET,
+            local_time_zone="America/Los_Angeles",
+        )
+        assert sp.to_properties_dict() == {
+            "sql.snapshot.write-mode": "fast-write",
+            "sql.state-ttl": "3600 s",
+            "sql.tables.scan.startup.mode": "latest-offset",
+            "sql.local-time-zone": "America/Los_Angeles",
+        }
+
+    def test_unset_fields_are_omitted(self):
+        sp = StatementProperties(snapshot_write_mode=SnapshotWriteMode.DEFAULT)
+        result = sp.to_properties_dict()
+        assert result == {"sql.snapshot.write-mode": "default"}
+        assert "sql.state-ttl" not in result
+
+    def test_extra_passes_through_including_unmodeled_keys(self):
+        sp = StatementProperties(extra={"sql.dry-run": True, "sql.some.future-option": "x"})
+        assert sp.to_properties_dict() == {"sql.dry-run": True, "sql.some.future-option": "x"}
+
+    def test_bare_string_value_reaches_wire_for_forward_compat(self):
+        """A not-yet-modeled server value is passable as a raw str on the typed field, and lands
+        verbatim -- to_properties_dict assigns the field directly, never `.value`."""
+        result = StatementProperties(snapshot_write_mode="turbo-write").to_properties_dict()
+        assert result == {"sql.snapshot.write-mode": "turbo-write"}
+
+    def test_scan_startup_bare_string_reaches_wire(self):
+        result = StatementProperties(scan_startup_mode="future-mode").to_properties_dict()
+        assert result == {"sql.tables.scan.startup.mode": "future-mode"}
+
+    @pytest.mark.parametrize(
+        ("kwargs", "wrong_type", "expected_type"),
+        [
+            ({"snapshot_write_mode": SnapshotMode.NOW}, "SnapshotMode", "SnapshotWriteMode"),
+            (
+                {"scan_startup_mode": SnapshotWriteMode.FAST_WRITE},
+                "SnapshotWriteMode",
+                "ScanStartupMode",
+            ),
+        ],
+    )
+    def test_wrong_enum_member_raises(self, kwargs, wrong_type, expected_type):
+        """A PropertyValue from the wrong property is a category error, rejected at construction."""
+        field_name = next(iter(kwargs))
+        with pytest.raises(
+            InterfaceError,
+            match=(
+                rf"{field_name} was given a {wrong_type}; "
+                rf"expected a {expected_type} or a raw str"
+            ),
+        ):
+            StatementProperties(**kwargs)
+
+    def test_correct_enum_and_bare_string_do_not_raise(self):
+        StatementProperties(snapshot_write_mode=SnapshotWriteMode.FAST_WRITE)
+        StatementProperties(snapshot_write_mode="anything-goes")
+        StatementProperties(scan_startup_mode=ScanStartupMode.TIMESTAMP)
+        StatementProperties(scan_startup_mode="anything-goes")
+
+    def test_extra_colliding_with_set_field_raises(self):
+        with pytest.raises(
+            InterfaceError, match=r"extra may not contain 'sql\.snapshot\.write-mode'"
+        ):
+            StatementProperties(
+                snapshot_write_mode=SnapshotWriteMode.FAST_WRITE,
+                extra={"sql.snapshot.write-mode": "fast-write"},
+            )
+
+    def test_extra_colliding_with_unset_field_still_raises(self):
+        """The collision rule keys off *modeled*, not *assigned*: the field is left unset here and
+        the extra key is still rejected -- one spelling per property, always via the field."""
+        with pytest.raises(InterfaceError, match=r"extra may not contain 'sql\.state-ttl'"):
+            StatementProperties(extra={"sql.state-ttl": "3600 s"})
+
+    def test_extra_collision_detected_when_keyed_by_enum_member(self):
+        """A Property member used as an extra key collides just like its raw string would."""
+        with pytest.raises(InterfaceError, match=r"extra may not contain 'sql\.state-ttl'"):
+            StatementProperties(extra={Property.STATE_TTL: "3600 s"})
+
+
+@pytest.mark.unit
 def test_enums_are_reexported_from_package_root():
     """Property, PropertyValue, and the value enums are importable straight off confluent_sql."""
     assert confluent_sql.Property is Property
     assert confluent_sql.PropertyValue is PropertyValue
     assert confluent_sql.SnapshotWriteMode is SnapshotWriteMode
     assert confluent_sql.SnapshotMode is SnapshotMode
+    assert confluent_sql.ScanStartupMode is ScanStartupMode
+    assert confluent_sql.StatementProperties is StatementProperties


### PR DESCRIPTION
# Frozen `StatementProperties`: a typed view over statement SET options

## Typed statement properties

- `StatementProperties` is a frozen, keyword-only dataclass giving callers a typed, autocomplete-
  friendly way to set the curated statement options, instead of hand-building a `{"sql.…": …}`
  dict. It lives in `statement_properties.py` alongside the #162 enums it composes.
- Fields (all optional, `None` = unset): `snapshot_write_mode: SnapshotWriteMode | str`,
  `state_ttl: timedelta`, `scan_startup_mode: ScanStartupMode | str`, `local_time_zone: str`, plus
  an `extra: PropertiesDict` escape hatch for options not yet modeled. Only explicitly set fields
  are emitted — so an instance never pins a server default nor collides with the driver-owned
  overlay (catalog/database/snapshot.mode), none of which it models.
- **Enum fields accept a bare string for forward compatibility.** An enum-typed field takes its own
  `PropertyValue` subclass *or* a raw `str`, so a caller can pass a Flink-side value this driver
  doesn't model yet (`snapshot_write_mode="turbo-write"`) without detouring through `extra` (which
  the collision rule below would then reject anyway). What is rejected — at construction, via
  `__post_init__` — is a *wrong-enum* member: `snapshot_write_mode=SnapshotMode.NOW` is a category
  error and raises `InterfaceError`; a bare string never does (Flink validates it server-side).
- `to_properties_dict() -> PropertiesDict` renders the instance to the wire dict: it seeds from
  `dict(extra)`, then overlays each set typed field under its `Property` key. It assigns the field
  value directly (not `.value`) so both enum members and bare forward-compat strings serialize
  correctly.
- **One spelling per property.** `extra` is only for un-modeled options, so `__post_init__` raises
  `InterfaceError` if `extra` carries any key a typed field already models — regardless of whether
  that field is set. There is never a second way to spell a modeled property.
- **`state_ttl` conversion.** A `timedelta` renders to a Flink `Duration` string via
  `_to_flink_duration`: whole seconds print as `"<n> s"` (so `timedelta(hours=1)` → `"3600 s"`),
  otherwise `"<n> ms"`; sub-millisecond precision (which Flink can't express) and negative
  durations raise `ValueError`.
- **`ScanStartupMode`** value enum added to `statement_properties.py` (deferred from #162 pending
  confirmed values): `earliest-offset`, `latest-offset`, `timestamp`, `specific-offsets`. These are
  Confluent's set for `scan.startup.mode` — deliberately *not* Apache Flink's, which additionally
  has `group-offsets` and defaults to it; Confluent omits it and defaults to `earliest-offset`.

## Connection downgrade path

- `Connection._resolve_properties` accepts a `StatementProperties` as well as a raw dict: it
  downgrades via `.to_properties_dict()` up front, then the existing validation + system overlay
  run unchanged. A reserved/driver-owned key smuggled in through `extra` is therefore still
  rejected, exactly as a raw dict's would be (pinned by test).
- Public `properties=` parameters widen to `PropertiesDict | StatementProperties | None` across the
  execute surface (`_execute_statement`, `Cursor.execute`, `execute_snapshot_ddl`,
  `execute_streaming_ddl`).
- **Wire-validation** (value types are str/int/bool, reserved-key rejection) stays in
  `_resolve_properties` — the single existing site — rather than duplicated into the dataclass; the
  #164 followup will relocate that logic into the property domain. `StatementProperties.__post_init__`
  owns only the object's *intrinsic coherence* (no wrong-enum field, no `extra`/typed-field
  collision) — a distinct concern from wire-validity, so the two don't overlap.

## Relationships

- Closes #163
- Child of #161 (Epic: Ergonomic Statement Properties)