### PR TITLE
Refactor how system-managed statement properties are merged with user-provided statement properties.

### DIFF
--- a/src/confluent_sql/connection.py
+++ b/src/confluent_sql/connection.py
@@ -41,7 +41,12 @@ from .retry import (
 )
 from .statement import LABEL_PREFIX as STATEMENT_LABEL_PREFIX
 from .statement import ChangelogRow, Statement
-from .statement_properties import Property, SnapshotMode, StatementProperties
+from .statement_properties import (
+    Property,
+    SnapshotMode,
+    StatementProperties,
+    validate_properties_dict,
+)
 from .tableflow import (
     TableflowPhase,
     TableflowStorage,
@@ -447,16 +452,6 @@ class Connection:
 
     _TABLEFLOW_TOPICS_PATH = "/tableflow/v1/tableflow-topics"
     """Control-plane base path for the Tableflow-topics resource (enable/get/disable)."""
-
-    _RESERVED_STATEMENT_PROPERTIES = {
-        Property.CURRENT_CATALOG,
-        Property.CURRENT_DATABASE,
-        Property.SNAPSHOT_MODE,
-    }
-    """Per-statement properties the driver owns and overlays itself from connection/execution state
-    (the active catalog, database, and snapshot mode). They are not knobs a caller may set, so
-    _resolve_properties rejects any of these appearing in a user-supplied properties dict rather
-    than silently letting the driver's overlay win."""
 
     environment_id: str
     compute_pool_id: str | None
@@ -1459,17 +1454,20 @@ class Connection:
 
         self._row_type_registry.register_row_type(class_for_flink_row)
 
-    def _resolve_properties(
+    def _build_statement_properties(
         self,
         properties: PropertiesDict | StatementProperties | None,
         execution_mode: ExecutionMode,
     ) -> PropertiesDict:
         """
-        Validate and merge user properties with system properties.
+        Normalize/validate user properties, then overlay system properties on top.
 
-        Validates the properties parameter and merges it with system-level properties
-        (catalog, database, snapshot mode). System properties always have precedence
-        and cannot be overridden by user input.
+        Normalization and validation (is it dict-shaped, are keys strings and values
+        str/int/bool, are any driver-owned keys present) is pure property-domain policy and
+        lives in `validate_properties_dict` -- this method just calls it, then stamps the
+        connection/execution overlay (catalog, database, snapshot mode) that only `Connection`
+        has the identity and execution-mode context to know. System properties always have
+        precedence and cannot be overridden by user input.
 
         Args:
             properties: Optional user-provided statement properties -- either a raw dict (keys
@@ -1484,34 +1482,7 @@ class Connection:
         Raises:
             InterfaceError: If properties parameter is invalid (not a dict, invalid keys/values).
         """
-        if isinstance(properties, StatementProperties):
-            properties = properties.to_properties_dict()
-
-        # Validate properties parameter if provided
-        if properties is not None:
-            if not isinstance(properties, dict):
-                raise InterfaceError(f"properties must be a dict, got {type(properties).__name__}")
-
-            for key, value in properties.items():
-                if not isinstance(key, str):
-                    raise InterfaceError(
-                        f"properties keys must be strings, got {type(key).__name__} for key {key!r}"
-                    )
-                if not isinstance(value, (str, int, bool)):
-                    raise InterfaceError(
-                        f"properties values must be str, int, or bool, "
-                        f"got {type(value).__name__} for key {key!r}"
-                    )
-                if key in self._RESERVED_STATEMENT_PROPERTIES:
-                    raise InterfaceError(f"'{key}' is a reserved system property.")
-
-        # Start with user properties (if provided), then overlay system properties
-        # This ensures system properties always win and cannot be overridden
-        merged_properties: PropertiesDict = {}
-
-        if properties is not None:
-            # User properties applied first
-            merged_properties.update(properties)
+        merged_properties = validate_properties_dict(properties)
 
         # Connection-level properties overlay (always set, cannot be overridden by user)
         merged_properties[Property.CURRENT_CATALOG] = self.environment_id
@@ -1581,7 +1552,7 @@ class Connection:
             )
 
         # Resolve and merge user properties with system properties
-        merged_properties = self._resolve_properties(properties, execution_mode)
+        merged_properties = self._build_statement_properties(properties, execution_mode)
 
         # Prefer the per-call compute pool over the connection default; either may be absent.
         # A falsy per-call value (None or "") means "unspecified" -- matching connect()'s

--- a/src/confluent_sql/statement_properties.py
+++ b/src/confluent_sql/statement_properties.py
@@ -11,7 +11,7 @@ string semantics -- rather than `enum.StrEnum`, because the repo floor is Python
 is 3.11+ (`(str, Enum)` is also the house style: `TableFormat`, `ConnectorState`, `TableflowPhase`).
 Members are genuine `str` instances: they compare and hash as their wire string, so they drop
 straight into `PropertiesDict`, satisfy the `isinstance(v, (str, int, bool))` validation in
-`Connection._resolve_properties`, JSON-serialize to the bare wire string, and (via `_PropertyEnum`)
+`validate_properties_dict`, JSON-serialize to the bare wire string, and (via `_PropertyEnum`)
 stringify to it in logs and error messages too -- all with no `.value` unwrapping at the call site.
 """
 
@@ -71,6 +71,17 @@ class Property(_PropertyEnum):
     SCAN_WATERMARK_ALIGNMENT_MAX_ALLOWED_DRIFT = (
         "sql.tables.scan.watermark-alignment.max-allowed-drift"
     )
+
+
+DRIVER_OWNED_PROPERTIES: frozenset[Property] = frozenset(
+    {Property.CURRENT_CATALOG, Property.CURRENT_DATABASE, Property.SNAPSHOT_MODE}
+)
+"""Statement properties the driver owns and overlays itself from connection/execution state (the
+active catalog, database, and snapshot mode). They are not knobs a caller may set, so
+`validate_properties_dict` rejects any of these appearing in a user-supplied properties dict rather
+than silently letting the driver's overlay win. Kept in lockstep with the overlay that stamps
+these keys (`Connection._build_statement_properties`) -- see the invariant test asserting the two
+sets are equal."""
 
 
 class PropertyValue(_PropertyEnum):
@@ -259,3 +270,51 @@ class StatementProperties:
         if self.local_time_zone is not None:
             props[Property.LOCAL_TIME_ZONE] = self.local_time_zone
         return props
+
+
+def validate_properties_dict(
+    properties: PropertiesDict | StatementProperties | None,
+) -> PropertiesDict:
+    """Normalize and validate a caller-supplied `properties` argument into a fresh wire dict.
+
+    Accepts a raw `PropertiesDict`, a `StatementProperties` (downgraded via `to_properties_dict()`),
+    or `None` (treated as empty). Validates that the result is a dict, every key is a `str`, every
+    value is `str | int | bool`, and no key is in `DRIVER_OWNED_PROPERTIES` -- those are stamped by
+    the driver's own connection/execution overlay and are not a caller knob.
+
+    Always returns a dict distinct from any dict the caller passed in, so a subsequent overlay step
+    can add keys without mutating caller state.
+
+    Raises:
+        InterfaceError: if `properties` is not a dict/StatementProperties/None, a key isn't a str,
+            a value isn't str/int/bool, or a key is driver-owned.
+    """
+    if properties is None:
+        return {}
+
+    if not isinstance(properties, (dict, StatementProperties)):
+        raise InterfaceError(
+            f"properties must be a dict or StatementProperties, got {type(properties).__name__}"
+        )
+
+    # to_properties_dict() already hands back a dict fresh from this call, owned by no one else --
+    # copying it again below would just be a second allocation for nothing. A raw dict, in
+    # contrast, is the caller's own object and must be copied before we or the overlay step touch
+    # it.
+    if downgraded_from_statement_properties := isinstance(properties, StatementProperties):
+        properties = properties.to_properties_dict()
+
+    for key, value in properties.items():
+        if not isinstance(key, str):
+            raise InterfaceError(
+                f"properties keys must be strings, got {type(key).__name__} for key {key!r}"
+            )
+        if not isinstance(value, (str, int, bool)):
+            raise InterfaceError(
+                f"properties values must be str, int, or bool, "
+                f"got {type(value).__name__} for key {key!r}"
+            )
+        if key in DRIVER_OWNED_PROPERTIES:
+            raise InterfaceError(f"'{key}' is a reserved system property.")
+
+    return properties if downgraded_from_statement_properties else dict(properties)

--- a/tests/unit/test_connection_byoidc_unit.py
+++ b/tests/unit/test_connection_byoidc_unit.py
@@ -212,7 +212,7 @@ class TestByoidcDatabaseOptional:
         under BYOIDC never trips the control-plane fail-closed guard (no CMK lookup involved)."""
         conn = _byoidc_connect(database=database)
 
-        properties = conn._resolve_properties(None, ExecutionMode.SNAPSHOT)
+        properties = conn._build_statement_properties(None, ExecutionMode.SNAPSHOT)
 
         assert properties["sql.current-catalog"] == "env-1"
         if expected_current_database is None:

--- a/tests/unit/test_connection_unit_properties.py
+++ b/tests/unit/test_connection_unit_properties.py
@@ -9,6 +9,7 @@ from confluent_sql import InterfaceError, connect
 from confluent_sql.connection import Connection
 from confluent_sql.execution_mode import ExecutionMode
 from confluent_sql.statement_properties import (
+    DRIVER_OWNED_PROPERTIES,
     Property,
     ScanStartupMode,
     SnapshotWriteMode,
@@ -172,11 +173,11 @@ class TestExecuteStatementProperties:
     def test_properties_enum_key_and_value_reach_wire_as_strings(
         self, invalid_credential_connection, mocker
     ):
-        """A bare Property key and PropertyValue value survive _resolve_properties and serialize to
-        their wire strings -- guards the public #162 promise (enum members are usable directly in
-        properties=) against a future normalization/re-validation step in the merge dropping or
-        mangling them. Wire strings are asserted as literals, independent of the enums under
-        test."""
+        """A bare Property key and PropertyValue value survive _build_statement_properties and
+        serialize to their wire strings -- guards the public #162 promise (enum members are usable
+        directly in properties=) against a future normalization/re-validation step in the merge
+        dropping or mangling them. Wire strings are asserted as literals, independent of the enums
+        under test."""
         request_mock = self.install_request_mock(invalid_credential_connection, mocker)
 
         invalid_credential_connection._execute_statement(
@@ -290,3 +291,28 @@ class TestExecuteStatementProperties:
                 ExecutionMode.SNAPSHOT,
                 properties={reserved_member: "user-value"},
             )
+
+
+@pytest.mark.unit
+class TestDriverOwnedPropertiesInvariant:
+    """`DRIVER_OWNED_PROPERTIES` and the overlay it gates must stay in lockstep (#166): every key
+    the overlay stamps is rejected from caller input, and vice versa."""
+
+    def test_overlay_stamped_keys_match_driver_owned_properties(self):
+        """Drives the overlay for real (database set, snapshot mode) with no user properties, so
+        the resulting key set is exactly what `_build_statement_properties` stamps -- not a
+        hand-duplicated literal that could drift from `DRIVER_OWNED_PROPERTIES` unnoticed."""
+        conn = connect(
+            environment_id="env-id",
+            organization_id="org-id",
+            compute_pool_id="cp-id",
+            cloud_provider="aws",
+            cloud_region="us-east-1",
+            flink_api_key="key",
+            flink_api_secret="secret",
+            database="mydb",
+        )
+
+        merged = conn._build_statement_properties({}, ExecutionMode.SNAPSHOT)
+
+        assert set(merged.keys()) == DRIVER_OWNED_PROPERTIES

--- a/tests/unit/test_statement_properties_unit.py
+++ b/tests/unit/test_statement_properties_unit.py
@@ -9,6 +9,7 @@ import pytest
 import confluent_sql
 from confluent_sql import InterfaceError
 from confluent_sql.statement_properties import (
+    DRIVER_OWNED_PROPERTIES,
     Property,
     PropertyValue,
     ScanStartupMode,
@@ -16,6 +17,7 @@ from confluent_sql.statement_properties import (
     SnapshotWriteMode,
     StatementProperties,
     _to_flink_duration,
+    validate_properties_dict,
 )
 
 # Every sql.* statement key from the "Available SET options" table, verbatim off the wire.
@@ -310,6 +312,77 @@ class TestStatementProperties:
         sp = StatementProperties(extra=source)
         source["sql.another-future-option"] = "y"
         assert sp.to_properties_dict() == {"sql.some.future-option": "x"}
+
+
+@pytest.mark.unit
+class TestDriverOwnedProperties:
+    """The frozenset of keys `validate_properties_dict` rejects from caller input (#166)."""
+
+    def test_is_exactly_catalog_database_and_snapshot_mode(self):
+        expected = {Property.CURRENT_CATALOG, Property.CURRENT_DATABASE, Property.SNAPSHOT_MODE}
+        assert expected == DRIVER_OWNED_PROPERTIES
+
+
+@pytest.mark.unit
+class TestValidatePropertiesDict:
+    """Normalization + validation of a caller-supplied `properties` argument (#166): downgrades a
+    `StatementProperties`, treats `None` as empty, and otherwise enforces the same dict/key/value
+    shape and driver-owned-key rejection `Connection._build_statement_properties` used to inline."""
+
+    def test_none_becomes_empty_dict(self):
+        assert validate_properties_dict(None) == {}
+
+    def test_statement_properties_is_downgraded(self):
+        sp = StatementProperties(snapshot_write_mode=SnapshotWriteMode.FAST_WRITE)
+        assert validate_properties_dict(sp) == {"sql.snapshot.write-mode": "fast-write"}
+
+    def test_plain_dict_passes_through_by_value(self):
+        """The returned dict is a distinct object from the caller's, so a subsequent overlay step
+        can add keys without mutating the caller's own dict."""
+        source: dict = {"custom-prop": "value"}
+        result = validate_properties_dict(source)
+        assert result == source
+        assert result is not source
+        result["another-prop"] = "other-value"
+        assert "another-prop" not in source
+
+    def test_rejects_non_dict(self):
+        with pytest.raises(
+            InterfaceError, match="properties must be a dict or StatementProperties, got str"
+        ):
+            validate_properties_dict("not-a-dict")  # type: ignore[arg-type]
+
+    def test_rejects_non_string_key(self):
+        with pytest.raises(InterfaceError, match="properties keys must be strings, got int"):
+            validate_properties_dict({123: "value"})  # type: ignore[dict-item]
+
+    @pytest.mark.parametrize(
+        "invalid_value",
+        [[1, 2, 3], {"nested": "dict"}, 3.14, None],
+    )
+    def test_rejects_invalid_value_type(self, invalid_value):
+        with pytest.raises(InterfaceError, match="properties values must be str, int, or bool"):
+            validate_properties_dict({"key": invalid_value})
+
+    @pytest.mark.parametrize(
+        ("key", "wire_key"),
+        [
+            ("sql.current-catalog", "sql.current-catalog"),
+            (Property.CURRENT_DATABASE, "sql.current-database"),
+            (Property.SNAPSHOT_MODE, "sql.snapshot.mode"),
+        ],
+    )
+    def test_rejects_driver_owned_key(self, key, wire_key):
+        """A driver-owned key is rejected whether supplied as a raw string or a `Property`
+        member."""
+        with pytest.raises(InterfaceError, match=f"'{wire_key}' is a reserved system property"):
+            validate_properties_dict({key: "user-value"})
+
+    def test_rejects_driver_owned_key_smuggled_through_statement_properties_extra(self):
+        with pytest.raises(
+            InterfaceError, match="'sql.snapshot.mode' is a reserved system property"
+        ):
+            validate_properties_dict(StatementProperties(extra={"sql.snapshot.mode": "off"}))
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Refactor how Connection and cursor-statement-mode statement properties are validated and merged with call-provided statement properties for cleanliness.

Closes #166.
Step of #161.